### PR TITLE
chore: add DAPS PRE-PROD chart and Argo CD app

### DIFF
--- a/pre-prod/argocd-apps/daps.yaml
+++ b/pre-prod/argocd-apps/daps.yaml
@@ -1,0 +1,17 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: daps
+spec:
+  project: project-daps
+  source:
+    repoURL: 'https://github.com/catenax-ng/catena-x-release-deployment'
+    path: pre-prod/daps
+    targetRevision: HEAD
+    plugin:
+      name: argocd-vault-plugin-helm
+  destination:
+    server: 'https://kubernetes.default.svc'
+    namespace: product-daps
+  syncPolicy:
+    automated: {}

--- a/pre-prod/daps/Chart.yaml
+++ b/pre-prod/daps/Chart.yaml
@@ -1,0 +1,12 @@
+apiVersion: v2
+name: daps
+description: PRE-PROD deployment of the daps release
+type: application
+version: 0.1.0
+appVersion: "1.7.1"
+
+dependencies:
+  - name: omejdn-server
+    alias: daps
+    version: 1.7.1
+    repository: "https://catenax-ng.github.io/product-DAPS/"

--- a/pre-prod/daps/values.yaml
+++ b/pre-prod/daps/values.yaml
@@ -1,0 +1,11 @@
+daps:
+  ingress:
+    enabled: true
+    host: daps.pre-prod.demo.catena-x.net
+    pathPrefix: "/"
+    rootPath: "/"
+    tls:
+      enabled: true
+      certMgr:
+        enabled: true
+        issuer: "letsencrypt-prod"


### PR DESCRIPTION
Will add the Argo CD Application, that will deploy the pre-prod chart.
Only initial configuration done. Other configuration has to be set by the DAPS team