### PR TITLE
fix: adjust SLDT pre-prod config

### DIFF
--- a/pre-prod/sldt/Chart.yaml
+++ b/pre-prod/sldt/Chart.yaml
@@ -10,7 +10,3 @@ dependencies:
     alias: registry
     version: 0.2.1
     repository: "https://www.eclipse.org/tractusx/charts/"
-  - name: semantic-hub
-    alias: semantic-hub
-    version: 0.1.1
-    repository: "https://www.eclipse.org/tractusx/charts/"

--- a/pre-prod/sldt/Chart.yaml
+++ b/pre-prod/sldt/Chart.yaml
@@ -8,5 +8,5 @@ appVersion: "0.1.0"
 dependencies:
   - name: registry
     alias: registry
-    version: 0.2.1
+    version: 0.2.2
     repository: "https://www.eclipse.org/tractusx/charts/"

--- a/pre-prod/sldt/values.yaml
+++ b/pre-prod/sldt/values.yaml
@@ -1,17 +1,53 @@
 registry:
+  enablePostgres: true
   registry:
     image: ghcr.io/catenax-ng/registry:0.2.0-M2-multi-tenancy
+    replicaCount: 1
+    imagePullPolicy: Always
     imagePullSecrets:
       - name: machineuser-pull-secret-ro
+    containerPort: 4243
     host: semantics.pre-prod.demo.catena-x.net
+    ## If 'authentication' is set to false, no OAuth authentication is enforced
+    authentication: true
+    idpIssuerUri: <path:semantics/data/authentication#keycloak-idp-preprod>
+    idpClientId: <path:semantics/data/authentication#idpClientIdRegistry-preprod>
+    service:
+      port: 8080
+      type: ClusterIP
+    dataSource:
+      driverClassName: org.postgresql.Driver
+      ## The url, user, and password parameter will be ignored if 'enablePostgres' is set to true.
+      ## In that case the postgresql auth parameters are used.
+      url: jdbc:postgresql://semantic-services-postgresql:5432/registry
+      user: catenax
+      password: <path:semantics/data/authentication#dbpassword>
     ingress:
       enabled: true
       tls: true
       urlPrefix: /registry
       className: nginx
       annotations:
+        cert-manager.io/cluster-issuer: letsencrypt-prod
         nginx.ingress.kubernetes.io/rewrite-target: /$2
         nginx.ingress.kubernetes.io/use-regex: "true"
         nginx.ingress.kubernetes.io/enable-cors: "true"
         nginx.ingress.kubernetes.io/cors-allow-credentials: "true"
         nginx.ingress.kubernetes.io/x-forwarded-prefix: /registry
+    resources:
+      limits:
+        memory: "1024Mi"
+      requests:
+        memory: "512Mi"
+  postgresql:
+    primary:
+      persistence:
+        enabled: true
+        size: 8Gi
+    service:
+      ports:
+        postgresql: 5432
+    auth:
+      username: catenax
+      password: <path:semantics/data/authentication#dbpassword>
+      database: registry

--- a/pre-prod/sldt/values.yaml
+++ b/pre-prod/sldt/values.yaml
@@ -15,27 +15,3 @@ registry:
         nginx.ingress.kubernetes.io/enable-cors: "true"
         nginx.ingress.kubernetes.io/cors-allow-credentials: "true"
         nginx.ingress.kubernetes.io/x-forwarded-prefix: /registry
-
-
-semantic-hub:
-  hub:
-    image: ghcr.io/catenax-ng/semantic-hub:0.1.0-M2
-    imagePullSecrets:
-      - name: machineuser-pull-secret-ro
-    host: semantics.pre-prod.demo.catena-x.net
-    ingress:
-      ## Enable ingress for the Semantic Hub
-      enabled: true
-      ## Enable TLS (e.g. by using cert-manager)
-      tls: true
-      ## The secret name that contains the necessary 'tls.crt' and 'tls.key' entries
-      ## When using cert-manager this secret is created automatically
-      tlsSecretName: tls-secret
-      urlPrefix: /hub
-      className: nginx
-      annotations:
-        nginx.ingress.kubernetes.io/rewrite-target: /$2
-        nginx.ingress.kubernetes.io/use-regex: "true"
-        nginx.ingress.kubernetes.io/enable-cors: "true"
-        nginx.ingress.kubernetes.io/cors-allow-credentials: "true"
-        nginx.ingress.kubernetes.io/x-forwarded-prefix: /hub


### PR DESCRIPTION
After clarification with release management, only the SLDT registry is needed for the pre-prod environment.
After clarification with SLDT devs, the configuration is adjusted to match their helm chart requirements.
Unfortunately the contributions can - as of now - not been done by them