### PR TITLE
chore: onboard daps registration service #A1ODT-1036

### DIFF
--- a/pre-prod/argocd-apps/daps-registration-service.yaml
+++ b/pre-prod/argocd-apps/daps-registration-service.yaml
@@ -1,0 +1,17 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: daps-registration-service
+spec:
+  project: project-daps
+  source:
+    repoURL: 'https://github.com/catenax-ng/catena-x-release-deployment'
+    path: pre-prod/daps-registration-service
+    targetRevision: HEAD
+    plugin:
+      name: argocd-vault-plugin-helm
+  destination:
+    server: 'https://kubernetes.default.svc'
+    namespace: product-daps
+  syncPolicy:
+    automated: {}

--- a/pre-prod/daps-registration-service/Chart.yaml
+++ b/pre-prod/daps-registration-service/Chart.yaml
@@ -1,0 +1,12 @@
+apiVersion: v2
+name: daps-registration-service
+description: PRE-PROD deployment of the daps-registration-service release
+type: application
+version: 0.1.0
+appVersion: "1.0.4"
+
+dependencies:
+  - name: daps-reg-service
+    alias: daps-registration
+    version: 1.0.4
+    repository: "https://catenax-ng.github.io/product-daps-registration-service/"

--- a/pre-prod/daps-registration-service/values.yaml
+++ b/pre-prod/daps-registration-service/values.yaml
@@ -1,0 +1,1 @@
+daps-registration:

--- a/pre-prod/daps-registration-service/values.yaml
+++ b/pre-prod/daps-registration-service/values.yaml
@@ -1,1 +1,20 @@
 daps-registration:
+  ingress:
+    enabled: true
+    hosts:
+      - host: daps-registration.beta.demo.catena-x.net
+        paths:
+          - path: /
+            pathType: Prefix
+    tls:
+      enabled: true
+  drs:
+    secret:
+      secretName: "<path:devsecops/data/preprod/daps-registration/#secretName>"
+      clientId: "<path:devsecops/data/preprod/daps-registration/#clientId>"
+      clientSecret: "<path:devsecops/data/preprod/daps-registration/#clientSecret>"
+      authServerUrl: "<path:devsecops/data/preprod/daps-registration/#authServerUrl>"
+      realm: "<path:devsecops/data/preprod/daps-registration/#realm>"
+      resource: "<path:devsecops/data/preprod/daps-registration/#resource>"
+      apiUri: "<path:devsecops/data/preprod/daps-registration/#apiUri>"
+      tokenUri: "<path:devsecops/data/preprod/daps-registration/#tokenUri>"


### PR DESCRIPTION
This PR contains the initial setup for onboarding DAPS registration service on PRE-PROD.
Secrets in Vault exist, but are still empty. Clarifying content in the background.
Chart also does not yet have the possibility to specify a tls-secret manually