### PR TITLE
Update MIW Chart.yml to be inline with Tractus-X

### DIFF
--- a/pre-prod/managed-identity-wallets/Chart.yaml
+++ b/pre-prod/managed-identity-wallets/Chart.yaml
@@ -8,5 +8,5 @@ appVersion: "0.1.0"
 dependencies:
   - name: managed-identity-wallets
     alias: managed-identity-wallets
-    version: 0.5.8
+    version: 0.5.9
     repository: "https://catenax-ng.github.io/product-core-managed-identity-wallets-cd/"


### PR DESCRIPTION
To be in-line with the release version in Tractus-X updating the chart version to 0.5.9 which refers to app version 2.1.0