### PR TITLE
Persist stable 3.2 deployment

### DIFF
--- a/stable-3.2/.helmignore
+++ b/stable-3.2/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/stable-3.2/Chart.yaml
+++ b/stable-3.2/Chart.yaml
@@ -1,0 +1,30 @@
+apiVersion: v2
+name: stable-3.2
+description: Chart for Tractus-X stable release 3.2
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "STABLE-3.2"
+
+dependencies:
+  - name: agent-connector-memory
+    alias: provider-agent
+    repository: https://eclipse-tractusx.github.io/charts/dev
+    version: 1.9.8

--- a/stable-3.2/values-stable.yaml
+++ b/stable-3.2/values-stable.yaml
@@ -1,0 +1,3 @@
+provider-agent:
+  participant:
+    id: BPNL000000000001

--- a/stable-3.2/values.yaml
+++ b/stable-3.2/values.yaml
@@ -1,0 +1,83 @@
+provider-agent:
+  nameOverride: agent-connector-provider
+  fullnameOverride: agent-connector-provider
+  vault:
+    hashicorp:
+      enabled: true
+      url: https://vault.demo.catena-x.net
+      token: s.XRMTpxjFiEmCN6iPg4itBdXv
+      healthCheck:
+        enabled: false
+        standbyOk: true
+      paths:
+        secret: /v1/knowledge
+    secretNames:
+      transferProxyTokenSignerPrivateKey: oem-key
+      transferProxyTokenSignerPublicKey: oem-cert
+      transferProxyTokenEncryptionAesKey: oem-symmetric-key
+  controlplane:
+    securityContext:
+      readOnlyRootFilesystem: false
+    image:
+      pullPolicy: Always
+    ssi:
+      miw:
+        url: "https://managed-identity-wallets-new.stable.demo.catena-x.net"
+        authorityId: "BPNL00000003CRHK"
+      oauth:
+        tokenurl: "https://centralidp.stable.demo.catena-x.net/auth/realms/CX-Central/protocol/openid-connect/token"
+        client:
+          id: "sa4"
+          secretAlias: "stable-provider-miw"
+    endpoints:
+      management:
+        authKey: "dwt6stvctwewv3vtf624"
+    ingresses:
+      - enabled: true
+        hostname: "agent-provider-cp.stable.demo.catena-x.net"
+        endpoints:
+          - protocol
+          - management
+          - control
+        tls:
+          enabled: true
+  dataplanes:
+    dataplane:
+      securityContext:
+        readOnlyRootFilesystem: false
+      image:
+        pullPolicy: Always
+      configs:
+        dataspace.ttl: |-
+          ################################################
+          # Catena-X BT Agent Bootstrap
+          ################################################
+          @prefix : <GraphAsset?local=Dataspace> .
+          @prefix cx: <https://raw.githubusercontent.com/catenax-ng/product-knowledge/main/ontology/cx_ontology.ttl#> .
+          @prefix cx-common: <https://w3id.org/catenax/ontology/common#> .
+          @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+          @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+          @prefix bpnl: <bpn:legal:> .
+          @base <GraphAsset?local=Dataspace> .
+
+          bpnl:BPNL000000000001 cx:hasBusinessPartnerNumber "BPNL000000000001"^^xsd:string;
+                                cx:hasConnector <edcs://agent-provider-cp.stable.demo.catena-x.net>;
+                                cx-common:hasConnector <edcs://agent-provider-cp.stable.demo.catena-x.net>.
+
+          bpnl:BPNL0000000005VV cx:hasBusinessPartnerNumber "BPNL0000000005VV"^^xsd:string;
+                                cx:hasConnector <edcs://agent-consumer-cp.stable.demo.catena-x.net>;
+                                cx-common:hasConnector <edcs://agent-consumer-cp.stable.demo.catena-x.net>.
+      agent:
+        connectors:
+          - https://agent-provider-cp.stable.demo.catena-x.net
+
+      ingresses:
+        - enabled: true
+          hostname: "agent-provider-dp.stable.demo.catena-x.net"
+          endpoints:
+            - public
+            - default
+            - control
+            - callback
+          tls:
+            enabled: true

--- a/stable/23.12/agent-consumer-connector.yaml
+++ b/stable/23.12/agent-consumer-connector.yaml
@@ -1,0 +1,115 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: agent-consumer-connector
+  namespace: argocd
+spec:
+  destination:
+    namespace: product-knowledge
+    server: https://kubernetes.default.svc
+  project: project-knowledge
+  source:
+    repoURL: https://eclipse-tractusx.github.io/charts/dev
+    targetRevision: 1.9.8
+    chart: agent-connector-memory
+    plugin:
+      env:
+        - name: HELM_VALUES
+          value: |
+            participant:
+              id: BPNL0000000005VV
+            nameOverride: agent-connector-consumer
+            fullnameOverride: agent-connector-consumer
+            vault:
+              hashicorp:
+                enabled: true
+                url: https://vault.demo.catena-x.net
+                token: s.XRMTpxjFiEmCN6iPg4itBdXv
+                healthCheck:
+                  enabled: false
+                  standbyOk: true
+                paths:
+                  secret: /v1/knowledge
+              secretNames:
+                transferProxyTokenSignerPrivateKey: consumer-key
+                transferProxyTokenSignerPublicKey: consumer-cert
+                transferProxyTokenEncryptionAesKey: consumer-symmetric-key
+            controlplane:
+              securityContext:
+                readOnlyRootFilesystem: false
+              image:
+                pullPolicy: Always
+              ssi:
+                miw:
+                  # -- MIW URL
+                  url: "https://managed-identity-wallets-new-23-12.stable.demo.catena-x.net"
+                  # -- The BPN of the issuer authority
+                  authorityId: "BPNL00000003CRHK"
+                oauth:
+                  # -- The URL (of KeyCloak), where access tokens can be obtained
+                  tokenurl: "https://centralidp-23-12.stable.demo.catena-x.net/auth/realms/CX-Central/protocol/openid-connect/token"
+                  client:
+                    # -- The client ID for KeyCloak
+                    id: "sa5"
+                    # -- The alias under which the client secret is stored in the vault.
+                    secretAlias: "stable-consumer-miw"
+              endpoints:
+                management:
+                  authKey: "dwt6stvctwewv3vtf624"
+              ## Ingress declaration to expose the network service.
+              ingresses:
+                - enabled: true
+                  # -- The hostname to be used to precisely map incoming traffic onto the underlying network service
+                  hostname: "agent-consumer-cp-23-12.stable.demo.catena-x.net"
+                  # -- EDC endpoints exposed by this ingress resource
+                  endpoints:
+                    - protocol
+                    - management
+                    - control
+                  # -- Enables TLS on the ingress resource
+                  tls:
+                    enabled: true
+            dataplanes:
+              dataplane:
+                securityContext:
+                  readOnlyRootFilesystem: false
+                image:
+                  pullPolicy: Always
+                configs:
+                  dataspace.ttl: |-
+                    ################################################
+                    # Catena-X BT Agent Bootstrap
+                    ################################################
+                    @prefix : <GraphAsset?local=Dataspace> .
+                    @prefix cx: <https://raw.githubusercontent.com/catenax-ng/product-knowledge/main/ontology/cx_ontology.ttl#> .
+                    @prefix cx-common: <https://w3id.org/catenax/ontology/common#> .
+                    @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+                    @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+                    @prefix bpnl: <bpn:legal:> .
+                    @base <GraphAsset?local=Dataspace> .
+
+                    bpnl:BPNL000000000001 cx:hasBusinessPartnerNumber "BPNL000000000001"^^xsd:string;
+                                          cx:hasConnector <edcs://agent-provider-cp-23-12.stable.demo.catena-x.net>;
+                                          cx-common:hasConnector <edcs://agent-provider-cp-23-12.stable.demo.catena-x.net>.
+
+                    bpnl:BPNL0000000005VV cx:hasBusinessPartnerNumber "BPNL0000000005VV"^^xsd:string;
+                                          cx:hasConnector <edcs://agent-consumer-cp-23-12.stable.demo.catena-x.net>;
+                                          cx-common:hasConnector <edcs://agent-consumer-cp-23-12.stable.demo.catena-x.net>.
+                agent:
+                  # synchronization: 360000
+                  connectors:
+                    - https://agent-provider-cp-23-12.stable.demo.catena-x.net
+
+                ## Ingress declaration to expose the network service.
+                ingresses:
+                  - enabled: true
+                    hostname: "agent-consumer-dp-23-12.stable.demo.catena-x.net"
+                    # -- EDC endpoints exposed by this ingress resource
+                    endpoints:
+                      - public
+                      - default
+                      - control
+                      - callback
+                    # -- Enables TLS on the ingress resource
+                    tls:
+                      enabled: true

--- a/stable/23.12/agent-provider-connector.yaml
+++ b/stable/23.12/agent-provider-connector.yaml
@@ -1,0 +1,115 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: agent-provider-connector
+  namespace: argocd
+spec:
+  destination:
+    namespace: product-knowledge
+    server: https://kubernetes.default.svc
+  project: project-knowledge
+  source:
+    repoURL: 'https://eclipse-tractusx.github.io/charts/dev'
+    targetRevision: 1.9.8
+    chart: agent-connector-memory
+    plugin:
+      env:
+        - name: HELM_VALUES
+          value: |
+            participant:
+              id: BPNL000000000001
+            nameOverride: agent-connector-provider
+            fullnameOverride: agent-connector-provider
+            vault:
+              hashicorp:
+                enabled: true
+                url: https://vault.demo.catena-x.net
+                token: s.XRMTpxjFiEmCN6iPg4itBdXv
+                healthCheck:
+                  enabled: false
+                  standbyOk: true
+                paths:
+                  secret: /v1/knowledge
+              secretNames:
+                transferProxyTokenSignerPrivateKey: oem-key
+                transferProxyTokenSignerPublicKey: oem-cert
+                transferProxyTokenEncryptionAesKey: oem-symmetric-key
+            controlplane:
+              securityContext:
+                readOnlyRootFilesystem: false
+              image:
+                pullPolicy: Always
+              ssi:
+                miw:
+                  # -- MIW URL
+                  url: "https://managed-identity-wallets-new-23-12.stable.demo.catena-x.net"
+                  # -- The BPN of the issuer authority
+                  authorityId: "BPNL00000003CRHK"
+                oauth:
+                  # -- The URL (of KeyCloak), where access tokens can be obtained
+                  tokenurl: "https://centralidp-23-12.stable.demo.catena-x.net/auth/realms/CX-Central/protocol/openid-connect/token"
+                  client:
+                    # -- The client ID for KeyCloak
+                    id: "sa4"
+                    # -- The alias under which the client secret is stored in the vault.
+                    secretAlias: "stable-provider-miw"
+              endpoints:
+                management:
+                  authKey: "dwt6stvctwewv3vtf624"
+              ## Ingress declaration to expose the network service.
+              ingresses:
+                - enabled: true
+                  # -- The hostname to be used to precisely map incoming traffic onto the underlying network service
+                  hostname: "agent-provider-cp-23-12.stable.demo.catena-x.net"
+                  # -- EDC endpoints exposed by this ingress resource
+                  endpoints:
+                    - protocol
+                    - management
+                    - control
+                  # -- Enables TLS on the ingress resource
+                  tls:
+                    enabled: true
+            dataplanes:
+              dataplane:
+                securityContext:
+                  readOnlyRootFilesystem: false
+                image:
+                  pullPolicy: Always
+                configs:
+                  dataspace.ttl: |-
+                    ################################################
+                    # Catena-X BT Agent Bootstrap
+                    ################################################
+                    @prefix : <GraphAsset?local=Dataspace> .
+                    @prefix cx: <https://raw.githubusercontent.com/catenax-ng/product-knowledge/main/ontology/cx_ontology.ttl#> .
+                    @prefix cx-common: <https://w3id.org/catenax/ontology/common#> .
+                    @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+                    @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+                    @prefix bpnl: <bpn:legal:> .
+                    @base <GraphAsset?local=Dataspace> .
+
+                    bpnl:BPNL000000000001 cx:hasBusinessPartnerNumber "BPNL000000000001"^^xsd:string;
+                                          cx:hasConnector <edcs://agent-provider-cp-23-12.stable.demo.catena-x.net>;
+                                          cx-common:hasConnector <edcs://agent-provider-cp-23-12.stable.demo.catena-x.net>.
+
+                    bpnl:BPNL0000000005VV cx:hasBusinessPartnerNumber "BPNL0000000005VV"^^xsd:string;
+                                          cx:hasConnector <edcs://agent-consumer-cp-23-12.stable.demo.catena-x.net>;
+                                          cx-common:hasConnector <edcs://agent-consumer-cp-23-12.stable.demo.catena-x.net>.
+                agent:
+                  #synchronization: 360000
+                  connectors:
+                    - https://agent-provider-cp-23-12.stable.demo.catena-x.net
+
+                ## Ingress declaration to expose the network service.
+                ingresses:
+                  - enabled: true
+                    hostname: "agent-provider-dp-23-12.stable.demo.catena-x.net"
+                    # -- EDC endpoints exposed by this ingress resource
+                    endpoints:
+                      - public
+                      - default
+                      - control
+                      - callback
+                    # -- Enables TLS on the ingress resource
+                    tls:
+                      enabled: true

--- a/stable/23.12/bpdm.yaml
+++ b/stable/23.12/bpdm.yaml
@@ -1,0 +1,264 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: bpdm-stable
+  namespace: argocd
+spec:
+  project: project-bpdm
+  destination:
+    server: 'https://kubernetes.default.svc'
+    namespace: product-bpdm
+  source:
+    repoURL: 'https://eclipse-tractusx.github.io/charts/dev'
+    targetRevision: 3.0.4
+    chart: bpdm
+    plugin:
+      env:
+        - name: HELM_VALUES
+          value: |
+            bpdm-gate:
+              fullnameOverride: bpdm-stable-gate-test-company
+              enabled: true
+              replicaCount: 1
+              resources:
+                limits:
+                  cpu: 800m
+                  memory: 2Gi
+                requests:
+                  cpu: 300m
+                  memory: 2Gi
+              springProfiles:
+                - auth
+              ingress:
+                enabled: true
+                hosts:
+                  - host: business-partners-23-12.stable.demo.catena-x.net
+                    paths:
+                      - path: "/companies/test-company"
+                        pathType: Prefix
+                tls:
+                  - secretName: tls-secret
+                    hosts:
+                      - business-partners-23-12.stable.demo.catena-x.net
+              livenessProbe:
+                httpGet:
+                  path: "/companies/test-company/actuator/health/liveness"
+              readinessProbe:
+                httpGet:
+                  path: "/companies/test-company/actuator/health/readiness"
+              startupProbe:
+                httpGet:
+                  path: "/companies/test-company/actuator/health/readiness"
+              applicationConfig:
+                server:
+                  servlet:
+                    context-path: "/companies/test-company"
+                bpdm:
+                  gate-security:
+                    changeCompanyInputData: update_company_data
+                    changeCompanyOutputData: update_company_data
+                    readCompanyInputData: view_company_data
+                    readCompanyOutputData: view_shared_data
+                  security:
+                    auth-server-url: https://centralidp-23-12.stable.demo.catena-x.net/auth
+                    realm: CX-Central
+                    client-id: Cl16-CX-BPDMGate
+                springdoc:
+                  swagger-ui:
+                    oauth:
+                      client-id: Cl2-CX-Portal
+              applicationSecrets:
+                spring:
+                  datasource:
+                    password: '<path:bpdm/data/stable/pool/postgresql#password>'
+              postgres:
+                enabled: false
+            bpdm-pool:
+              fullnameOverride: bpdm-stable-pool
+              enabled: true
+              springProfiles:
+                - auth
+              resources:
+                limits:
+                  cpu: 800m
+                  memory: 2Gi
+                requests:
+                  cpu: 300m
+                  memory: 2Gi
+              ingress:
+                enabled: true
+                annotations:
+                  kubernetes.io/ingress.class: nginx
+                  nginx.ingress.kubernetes.io/backend-protocol: "HTTP"
+                hosts:
+                  - host: business-partners-23-12.stable.demo.catena-x.net
+                    paths:
+                      - path: /pool
+                        pathType: Prefix
+                tls:
+                  - secretName: tls-secret
+                    hosts:
+                      - business-partners-23-12.stable.demo.catena-x.net
+              livenessProbe:
+                httpGet:
+                  path: "/pool/actuator/health/liveness"
+              readinessProbe:
+                httpGet:
+                  path: "/pool/actuator/health/readiness"
+              startupProbe:
+                httpGet:
+                  path: "/pool/actuator/health/readiness"
+              applicationConfig:
+                server:
+                  servlet:
+                    context-path: "/pool"
+                bpdm:
+                  pool-security:
+                    readPoolPartnerData: view_company_data
+                    changePoolPartnerData: add_company_data
+                    readMetaData: view_company_data
+                    changeMetaData: add_company_data
+                    manageOpensearch: add_company_data
+                  opensearch:
+                    # every hour at minute 30
+                    export-scheduler-cron-expr: 0 30 * * * *
+                  security:
+                    auth-server-url: https://centralidp-23-12.stable.demo.catena-x.net/auth
+                    realm: CX-Central
+                    client-id: Cl7-CX-BPDM
+                springdoc:
+                  swagger-ui:
+                    oauth:
+                      client-id: Cl2-CX-Portal
+              applicationSecrets:
+                spring:
+                  datasource:
+                    password: '<path:bpdm/data/stable/pool/postgresql#password>'
+              opensearch:
+                fullnameOverride: "bpdm-stable-opensearch"
+
+            bpdm-bridge-dummy:
+              fullnameOverride: bpdm-stable-bridge
+              springProfiles:
+                - auth
+              ingress:
+                enabled: true
+                annotations:
+                  kubernetes.io/ingress.class: nginx
+                  nginx.ingress.kubernetes.io/backend-protocol: "HTTP"
+                hosts:
+                  - host: business-partners-23-12.stable.demo.catena-x.net
+                    paths:
+                      - path: /bridge
+                        pathType: Prefix
+                tls:
+                  - secretName: tls-secret
+                    hosts:
+                      - business-partners-23-12.stable.demo.catena-x.net
+              livenessProbe:
+                httpGet:
+                  path: "/bridge/actuator/health/liveness"
+              readinessProbe:
+                httpGet:
+                  path: "/bridge/actuator/health/readiness"
+              startupProbe:
+                httpGet:
+                  path: "/bridge/actuator/health/readiness"
+              resources:
+                limits:
+                  cpu: 800m
+                  memory: 2Gi
+                requests:
+                  cpu: 300m
+                  memory: 2Gi
+              applicationConfig:
+                server:
+                  servlet:
+                    context-path: "/bridge"
+                bpdm:
+                  bridge:
+                    syncAuthorities: add_company_data
+                  pool:
+                    base-url: "http://bpdm-stable-pool:8080/pool"
+                  gate:
+                    base-url: "http://bpdm-stable-gate-test-company:8080/companies/test-company"
+                  security:
+                    auth-server-url: https://centralidp-23-12.stable.demo.catena-x.net/auth
+                    realm: CX-Central
+                    client-id: Cl7-CX-BPDM
+                spring:
+                  security:
+                    oauth2:
+                      client:
+                        registration:
+                          bridge-client:
+                            # Client ID used for getting token different from own Client to validate tokens
+                            client-id: sa-cl7-cx-7
+                        provider:
+                          catena-keycloak-provider:
+                            issuer-uri: https://centralidp-23-12.stable.demo.catena-x.net/auth/realms/CX-Central
+              applicationSecrets:
+                spring:
+                  datasource:
+                    password: '<path:bpdm/data/stable/pool/postgresql#password>'
+                bpdm:
+                  security:
+                    credentials:
+                      secret: '<path:bpdm/data/stable/admin-user#client-secret>'
+
+            opensearch:
+              masterService: ""
+              fullnameOverride: "bpdm-stable-opensearch"
+              enabled: true
+              replicas: 1
+              protocol: http
+              roles:
+                - master
+                - ingest
+                - data
+              resources:
+                limits:
+                  cpu: 300m
+                  memory: 2Gi
+                requests:
+                  cpu: 100m
+                  memory: 2Gi
+              config:
+                opensearch.yml: |
+                  # Bind to all interfaces because we don't know what
+                  # IP address Docker will assign to us.
+                  network.host: 0.0.0.0
+                  # Disable security
+                  plugins.security.disabled: true
+              securityConfig:
+                enabled: false
+              extraInitContainers:
+                # Image that performs the sysctl operation to modify Kernel settings
+                # needed sometimes to avoid boot errors
+                - name: sysctl
+                  image: docker.io/bitnami/bitnami-shell:10-debian-10-r199
+                  imagePullPolicy: "IfNotPresent"
+                  command:
+                    - /bin/bash
+                    - -ec
+                    - |
+                      CURRENT=`sysctl -n vm.max_map_count`;
+                      DESIRED="262144";
+                      if [ "$DESIRED" -gt "$CURRENT" ]; then
+                          sysctl -w vm.max_map_count=262144;
+                      fi;
+                      CURRENT=`sysctl -n fs.file-max`;
+                      DESIRED="65536";
+                      if [ "$DESIRED" -gt "$CURRENT" ]; then
+                          sysctl -w fs.file-max=65536;
+                      fi;
+                  securityContext:
+                    runAsUser: 0
+                    privileged: true
+
+            postgres:
+              auth:
+                postgresPassword: '<path:bpdm/data/stable/pool/postgresql#postgres-password>'
+                password: '<path:bpdm/data/stable/pool/postgresql#password>'
+              chart: bpdm
+

--- a/stable/23.12/bpndiscovery-service.yaml
+++ b/stable/23.12/bpndiscovery-service.yaml
@@ -1,0 +1,63 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: bpndiscovery-service
+  namespace: argocd
+spec:
+  project: project-semantics
+  destination:
+    server: 'https://kubernetes.default.svc'
+    namespace: product-semantics
+  source:
+    repoURL: 'https://eclipse-tractusx.github.io/charts/dev'
+    targetRevision: 0.1.11
+    chart: bpndiscovery
+    plugin:
+      env:
+        - name: HELM_VALUES
+          value: |
+            bpndiscovery:
+              enablePostgres: true
+              image:
+                imagePullPolicy: IfNotPresent
+              replicaCount: 1
+              containerPort: 4243
+              host: semantics-23-12.stable.demo.catena-x.net
+              ## If 'authentication' is set to false, no OAuth authentication is enforced
+              authentication: true
+              idp:
+                issuerUri: "https://centralidp-23-12.stable.demo.catena-x.net/auth/realms/CX-Central"
+                publicClientId: '<path:semantics/data/authentication#idpClientIdBpnDiscovery>'
+                bpnIdClaimName: bpn
+              ## Needed for the self-registration on discovery-finder
+              bpndiscoveryEndpoint:
+                allowedTypes: oen,wmi,passtype,manufacturerPartId
+                description: Service to discover BPN for different kind of type numbers
+                endpointAddress: https://semantics-23-12.stable.demo.catena-x.net/bpndiscovery
+                documentation: https://semantics-23-12.stable.demo.catena-x.net/bpndiscovery/swagger-ui/index.html
+              ## Configure discoveryFinderClient to register the bpn-discovery on discovery-finder.Properties needed for spring-security config.
+              discoveryfinderClient:
+                baseUrl: https://semantics-23-12.stable.demo.catena-x.net/discoveryfinder
+                registration:
+                  clientId: '<path:semantics/data/authentication#discoveryFinder-technical-user>'
+                  clientSecret: '<path:semantics/data/authentication#discoveryFinder-technical-user-password-stable>'
+                  authorizationGrantType: client_credentials
+                schedulerCronFrequency: "0 0 */1 * * *"
+                provider:
+                  tokenUri: https://centralidp-23-12.stable.demo.catena-x.net/auth/realms/CX-Central/protocol/openid-connect/token
+              dataSource:
+                driverClassName: org.postgresql.Driver
+                sqlInitPlatform: pg
+                ## The url, user, and password parameter will be ignored if 'enablePostgres' is set to true.
+                ## In that case the postgresql auth parameters are used.
+                url: jdbc:postgresql://semantic-services-postgresql:5432/bpndiscovery
+                user: catenax
+                password: '<path:semantics/data/authentication#dbpassword>'
+              ingress:
+                enabled: true
+                tls: true
+              postgresql:
+                auth:
+                  username: catenax
+                  password: '<path:semantics/data/authentication#dbpassword>'
+                  database: bpndiscovery

--- a/stable/23.12/centralidp.yaml
+++ b/stable/23.12/centralidp.yaml
@@ -1,0 +1,79 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: centralidp
+  namespace: argocd
+spec:
+  project: project-portal
+  destination:
+    server: 'https://kubernetes.default.svc'
+    namespace: product-portal
+  source:
+    repoURL: 'https://eclipse-tractusx.github.io/charts/dev'
+    targetRevision: 1.2.0
+    chart: centralidp
+    plugin:
+      env:
+        - name: HELM_VALUES
+          value: |
+            keycloak:
+              initContainers:
+                - name: import
+                  image: tractusx/portal-iam-consortia:v1.2.0
+                  imagePullPolicy: Always
+                  command:
+                    - sh
+                  args:
+                    - -c
+                    - |
+                      echo "Copying themes..."
+                      cp -R /import/themes/catenax-central/* /themes
+                      echo "Copying realms..."
+                      cp -R /import/catenax-central/stable/realms/* /realms
+                  volumeMounts:
+                  - name: themes
+                    mountPath: "/themes"
+                  - name: realms
+                    mountPath: "/realms"
+              ingress:
+                enabled: true
+                ingressClassName: nginx
+                hostname: centralidp-23-12.stable.demo.catena-x.net
+                annotations:
+                  cert-manager.io/cluster-issuer: letsencrypt-prod
+                  nginx.ingress.kubernetes.io/cors-allow-credentials: "true"
+                  nginx.ingress.kubernetes.io/cors-allow-methods: PUT, GET, POST, OPTIONS
+                  nginx.ingress.kubernetes.io/cors-allow-origin: https://centralidp-23-12.stable.demo.catena-x.net, http://localhost:3000
+                  nginx.ingress.kubernetes.io/enable-cors: "true"
+                  nginx.ingress.kubernetes.io/proxy-buffer-size: 128k
+                  nginx.ingress.kubernetes.io/proxy-buffering: "on"
+                  nginx.ingress.kubernetes.io/proxy-buffers-number: "20"
+                  nginx.ingress.kubernetes.io/use-regex: "true"
+                tls: true
+            secrets:
+              auth:
+                existingSecret:
+                  adminpassword: "<path:portal/data/stable/iam/centralidp-keycloak#admin-password>"
+                  managementpassword: "<path:portal/data/stable/iam/centralidp-keycloak#management-password>"
+              postgresql:
+                auth:
+                  existingSecret:
+                    postgrespassword: "<path:portal/data/stable/iam/centralidp-postgres#postgres-password>"
+                    password: "<path:portal/data/stable/iam/centralidp-postgres#password>"
+                    replicationPassword: "<path:portal/data/stable/iam/centralidp-postgres#replication-password>"
+            seeding:
+              enabled: true
+              initContainers:
+                - name: init-cx-central
+                  image: tractusx/portal-iam-consortia:v1.2.0
+                  imagePullPolicy: Always
+                  command:
+                    - sh
+                  args:
+                    - -c
+                    - |
+                      echo "Copying CX Central realm..."
+                      cp -R /import/catenax-central/stable/realms/* /app/realms
+                  volumeMounts:
+                  - name: realms
+                    mountPath: "app/realms"

--- a/stable/23.12/digital-product-pass.yaml
+++ b/stable/23.12/digital-product-pass.yaml
@@ -1,0 +1,193 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: digital-product-pass
+  namespace: argocd
+spec:
+  project: project-material-pass
+  destination:
+    server: 'https://kubernetes.default.svc'
+    namespace: product-material-pass
+  source:
+    repoURL: 'https://eclipse-tractusx.github.io/charts/dev'
+    targetRevision: 1.0.1
+    chart: digital-product-pass
+    helm:
+      valueFiles:
+        - values.yaml
+      parameters:
+        - name: backend.ingress.enabled
+          value: 'true'
+        - name: backend.avp.helm.clientId
+          value: sa2
+        - name: backend.avp.helm.clientSecret
+          value: fdug2SLMjjTBEBCth5zFjgdT9uP27Wyg
+        - name: backend.avp.helm.participantId
+          value: BPNL00000000CBA5
+        - name: backend.avp.helm.xApiKey
+          value: password
+      values: |-
+        frontend:
+          ingress:
+            enabled: true
+            #className: ""
+            annotations:
+              ingressClassName: nginx
+              # kubernetes.io/tls-acme: "true"
+              nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
+              nginx.ingress.kubernetes.io/ssl-passthrough: "false"
+              nginx.ingress.kubernetes.io/rewrite-target: /$2
+              nginx.ingress.kubernetes.io/backend-protocol: "HTTP"
+              nginx.ingress.kubernetes.io/service-upstream: "true"
+            hosts:
+              - host: materialpass-23-12.stable.demo.catena-x.net
+                paths:
+                  - path: /passport(/|$)(.*)
+                    pathType: Prefix
+            tls:
+              - secretName: tls-secret
+                hosts:
+                  - materialpass-23-12.stable.demo.catena-x.net
+
+          productpass:
+            backend_url: "materialpass-23-12.stable.demo.catena-x.net"
+            idp_url: "centralidp-23-12.stable.demo.catena-x.net/auth/"
+            keycloak:
+              clientId: "Cl13-CX-Battery"
+              realm: "CX-Central"
+              onLoad: "login-required"
+
+        backend:
+          ingress:
+            enabled: true
+            # className: "nginx"
+            annotations:
+              ingressClassName: nginx
+              # kubernetes.io/tls-acme: "true"
+              nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
+              nginx.ingress.kubernetes.io/ssl-passthrough: "false"
+              nginx.ingress.kubernetes.io/backend-protocol: "HTTP"
+            hosts:
+              - host: materialpass-23-12.stable.demo.catena-x.net
+                paths:
+                  - path: /
+                    pathType: Prefix
+            tls:
+              - secretName: tls-secret
+                hosts:
+                  - materialpass-23-12.stable.demo.catena-x.net
+
+          avp:
+            helm:
+              clientId: sa2
+              clientSecret: fdug2SLMjjTBEBCth5zFjgdT9uP27Wyg
+              xApiKey: password
+              participantId: BPNL00000000CBA5
+
+          application:
+            yml: |-
+              spring:
+                name: 'Catena-X Product Passport Consumer Backend'
+                main:
+                  allow-bean-definition-overriding: true
+                devtools:
+                  add-properties: false
+                jackson:
+                  serialization:
+                    indent_output: true
+
+              logging:
+                level:
+                  root: INFO
+                  utils: INFO
+
+              configuration:
+                maxRetries: 5
+
+                keycloak:
+                  realm: CX-Central
+                  resource: Cl13-CX-Battery
+                  tokenUri: 'https://centralidp-23-12.stable.demo.catena-x.net/auth/realms/CX-Central/protocol/openid-connect/token'
+                  userInfoUri: 'https://centralidp-23-12.stable.demo.catena-x.net/auth/realms/CX-Central/protocol/openid-connect/userinfo'
+
+                edc:
+                  endpoint: 'https://materialpass-23-12.stable.demo.catena-x.net/consumer'
+                  management: '/management/v2'
+                  catalog: '/catalog/request'
+                  negotiation: '/contractnegotiations'
+                  transfer: '/transferprocesses'
+                  receiverEndpoint: 'https://materialpass-23-12.stable.demo.catena-x.net/endpoint'
+                  delay:  100 # -- Negotiation status Delay in milliseconds in between async requests [<= 500]
+
+                security:
+                  check:
+                    enabled: false
+                    bpn: true
+                    edc: true
+
+                dtr:
+                  central: false
+                  centralUrl: 'https://semantics-23-12.stable.demo.catena-x.net/registry'
+                  assetId: 'digital-twin-registry'
+                  dspEndpointKey: 'dspEndpoint'
+                  endpointInterface: 'SUBMODEL-3.0'
+                  internalDtr: "https://materialpass-23-12.stable.demo.catena-x.net/BPNL000000000000" # -- If there is an internal DTR available it can be referenced here and will be injected in the list of DTRs
+                  decentralApis:
+                    search: "/lookup/shells/query"
+                    digitalTwin: "/shell-descriptors"
+                    subModel: "/submodel-descriptors"
+                  timeouts:
+                    search: 10
+                    negotiation: 40
+                    transfer: 10
+                    digitalTwin: 20
+                  temporaryStorage: true
+
+                discovery:
+                  endpoint: "https://semantics-23-12.stable.demo.catena-x.net/discoveryfinder/api/administration/connectors/discovery/search"
+                  bpn:
+                    key: "manufacturerPartId"
+                    searchPath: "/api/administration/connectors/bpnDiscovery/search"
+                  edc:
+                    key: "bpn"
+
+
+                process:
+                  store: true
+                  dir: 'process'
+                  indent: true
+                  signKey: 'ca138db29b3727b1927383184f155bb8cb2e0127ee33bba35fab846e240e98425be5fd68c7656445eced5ea0ea5b3bd2676f0b6f30105b16962da27333176b9e'
+
+                passport:
+                  dataTransfer:
+                    encrypt: true
+                    indent: true
+                    dir: "data/transfer"
+                  versions:
+                    - 'v3.0.1'
+
+                vault:
+                  type: 'local'
+                  file: 'vault.token.yml'
+                  pathSep: "."
+                  prettyPrint: true
+                  indent: 2
+                  defaultValue: '<Add secret value here>'
+                  attributes:
+                    - "client.id"
+                    - "client.secret"
+                    - "edc.apiKey"
+                    - "edc.participantId"
+
+              server:
+                error:
+                  include-message: ALWAYS
+                  include-binding-errors: ALWAYS
+                  include-stacktrace: ON_PARAM
+                  include-exception: false
+                port: 8888
+                tomcat:
+                  max-connections: 10000
+  syncPolicy:
+    syncOptions:
+      - Replace=true

--- a/stable/23.12/discovery-finder.yaml
+++ b/stable/23.12/discovery-finder.yaml
@@ -1,0 +1,55 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: discoveryfinder-service
+  namespace: argocd
+spec:
+  project: project-semantics
+  destination:
+    server: 'https://kubernetes.default.svc'
+    namespace: product-semantics
+  source:
+    repoURL: 'https://eclipse-tractusx.github.io/charts/dev'
+    targetRevision: 0.1.11
+    chart: discoveryfinder
+    plugin:
+      env:
+        - name: HELM_VALUES
+          value: |
+            discoveryfinder:
+              enablePostgres: true
+              image:
+                imagePullPolicy: IfNotPresent
+              replicaCount: 1
+              containerPort: 4243
+              host: semantics-23-12.stable.demo.catena-x.net
+              ## If 'authentication' is set to false, no OAuth authentication is enforced
+              authentication: true
+              properties:
+                discoveryfinder:
+                  # Initial Endpoint for edc discovery with type bpn
+                  initialEndpoints:
+                    - type: bpn
+                      endpointAddress: https://portal-backend-23-12.stable.demo.catena-x.net/api/administration/Connectors/discovery
+                      description: Service to discover connector endpoints based on bpns
+                      documentation: https://portal-backend-23-12.stable.demo.catena-x.net/api/administration/swagger/index.html
+              idp:
+                issuerUri: "https://centralidp-23-12.stable.demo.catena-x.net/auth/realms/CX-Central"
+                publicClientId: '<path:semantics/data/authentication#idpClientIdDiscoveryFinder>'
+              dataSource:
+                driverClassName: org.postgresql.Driver
+                sqlInitPlatform: pg
+                ## The url, user, and password parameter will be ignored if 'enablePostgres' is set to true.
+                ## In that case the postgresql auth parameters are used.
+                url: jdbc:postgresql://semantic-services-postgresql:5432/discoveryfinder
+                user: catenax
+                password: '<path:semantics/data/authentication#dbpassword>'
+              ingress:
+                enabled: true
+                tls: true
+              postgresql:
+                auth:
+                  username: catenax
+                  password: '<path:semantics/data/authentication#dbpassword>'
+                  database: discoveryfinder
+

--- a/stable/23.12/dpp-edc-consumer.yaml
+++ b/stable/23.12/dpp-edc-consumer.yaml
@@ -1,0 +1,175 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: dpp-edc-consumer
+  namespace: argocd
+spec:
+  project: project-material-pass
+  destination:
+    server: 'https://kubernetes.default.svc'
+    namespace: product-material-pass
+  source:
+    repoURL: 'https://eclipse-tractusx.github.io/charts/dev'
+    targetRevision: 0.5.0
+    chart: tractusx-connector
+    helm:
+      valueFiles:
+        - values.yaml
+      values: |
+        participant:
+          id: "BPNL00000000CBA5"
+
+        controlplane:
+          enabled: true
+          endpoints:
+            # -- default api for health checks, should not be added to any ingress
+            default:
+              # -- port for incoming api calls
+              port: 8080
+              # -- path for incoming api calls
+              path: /consumer/api
+            # -- data management api, used by internal users, can be added to an ingress and must not be internet facing
+            management:
+              # -- port for incoming api calls
+              port: 8081
+              # -- path for incoming api calls
+              path: /consumer/management
+              # -- authentication key, must be attached to each 'X-Api-Key' request header
+              authKey: password
+            # -- control api, used for internal control calls. can be added to the internal ingress, but should probably not
+            control:
+              # -- port for incoming api calls
+              port: 8083
+              # -- path for incoming api calls
+              path: /consumer/control
+            # -- ids api, used for inter connector communication and must be internet facing
+            protocol:
+              # -- port for incoming api calls
+              port: 8084
+              # -- path for incoming api calls
+              path: /consumer/api/v1/dsp
+            # -- metrics api, used for application metrics, must not be internet facing
+            metrics:
+              # -- port for incoming api calls
+              port: 9090
+              # -- path for incoming api calls
+              path: /consumer/metrics
+            # -- observability api with unsecured access, must not be internet facing
+            observability:
+              # -- port for incoming API calls
+              port: 8085
+              # -- observability api, provides /health /readiness and /liveness endpoints
+              path: /consumer/observability
+              # -- allow or disallow insecure access, i.e. access without authentication
+              insecure: true
+
+          ssi:
+            miw:
+              url: "https://managed-identity-wallets-new-23-12.stable.demo.catena-x.net"
+              authorityId: "BPNL00000003CRHK"
+            oauth:
+              tokenurl: "https://centralidp-23-12.stable.demo.catena-x.net/auth/realms/CX-Central/protocol/openid-connect/token"
+              client:
+                id: "sa3"
+                secretAlias: "stable-client-secret"
+            endpoint:
+              audience: https://materialpass-23-12.stable.demo.catena-x.net/consumer
+
+          ## Ingress declaration to expose the network service.
+          ingresses:
+            ## Public / Internet facing Ingress
+            - enabled: true
+              # -- The hostname to be used to precisely map incoming traffic onto the underlying network service
+              hostname: "materialpass-23-12.stable.demo.catena-x.net"
+              # -- Additional ingress annotations to add
+              annotations: {}
+              # -- EDC endpoints exposed by this ingress resource
+              endpoints:
+                - default
+                - management
+                - control
+                - protocol
+                - metrics
+                - observability
+              # -- Defines the [ingress class](https://kubernetes.io/docs/concepts/services-networking/ingress/#ingress-class)  to use
+              className: "nginx"
+              # -- TLS [tls class](https://kubernetes.io/docs/concepts/services-networking/ingress/#tls) applied to the ingress resource
+              tls:
+                # -- Enables TLS on the ingress resource
+                enabled: true
+                # -- If present overwrites the default secret name
+                secretName: "tls-secret"
+        dataplane:
+          enabled: true
+          endpoints:
+            default:
+              port: 8080
+              path: /consumer/api
+            public:
+              port: 8081
+              path: /consumer/api/public
+            control:
+              port: 8083
+              path: /consumer/api/dataplane/control
+            proxy:
+              port: 8186
+              path: /consumer/proxy
+            observability:
+              # -- port for incoming API calls
+              port: 8085
+              # -- observability api, provides /health /readiness and /liveness endpoints
+              path: /consumer/observability
+              # -- allow or disallow insecure access, i.e. access without authentication
+              insecure: true
+            metrics:
+              port: 9090
+              path: /consumer/metrics
+
+          ## Ingress declaration to expose the network service.
+          ingresses:
+            ## Public / Internet facing Ingress
+            - enabled: true
+              # -- The hostname to be used to precisely map incoming traffic onto the underlying network service
+              hostname: "materialpass-23-12.stable.demo.catena-x.net"
+              # -- Additional ingress annotations to add
+              annotations: {}
+              # -- EDC endpoints exposed by this ingress resource
+              endpoints:
+                - public
+              # -- Defines the [ingress class](https://kubernetes.io/docs/concepts/services-networking/ingress/#ingress-class)  to use
+              className: "nginx"
+              # -- TLS [tls class](https://kubernetes.io/docs/concepts/services-networking/ingress/#tls) applied to the ingress resource
+              tls:
+                # -- Enables TLS on the ingress resource
+                enabled: true
+                # -- If present overwrites the default secret name
+                secretName: "tls-secret"
+              ## Adds [cert-manager](https://cert-manager.io/docs/) annotations to the ingress resource
+              certManager:
+                # -- If preset enables certificate generation via cert-manager namespace scoped issuer
+                issuer: ""
+                # -- If preset enables certificate generation via cert-manager cluster-wide issuer
+                clusterIssuer: ""
+
+        postgresql:
+          username: dpp_user
+          password: dpp_password
+
+
+        vault:
+          hashicorp:
+            url: https://vault.demo.catena-x.net
+            token: s.nMWRzBOSupUC5iXyANzHC7Zo
+            paths:
+              secret:  /v1/material-pass
+              health: /v1/sys/health
+          secretNames:
+            transferProxyTokenSignerPrivateKey: ids-daps_key
+            transferProxyTokenSignerPublicKey: ids-daps_crt
+            transferProxyTokenEncryptionAesKey: edc-encryption-key
+
+        backendService:
+            httpProxyTokenReceiverUrl: "https://materialpass-23-12.stable.demo.catena-x.net/endpoint"
+  syncPolicy:
+    syncOptions:
+      - Replace=true

--- a/stable/23.12/dpp-edc-provider.yaml
+++ b/stable/23.12/dpp-edc-provider.yaml
@@ -1,0 +1,175 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: dpp-edc-provider
+  namespace: argocd
+spec:
+  project: project-material-pass
+  destination:
+    server: 'https://kubernetes.default.svc'
+    namespace: product-material-pass
+  source:
+    repoURL: 'https://eclipse-tractusx.github.io/charts/dev'
+    targetRevision: 0.5.0
+    chart: tractusx-connector
+    helm:
+      valueFiles:
+        - values.yaml
+      values: |
+        participant:
+          id: "BPNL00000000CBA5"
+
+        controlplane:
+          enabled: true
+          endpoints:
+            # -- default api for health checks, should not be added to any ingress
+            default:
+              # -- port for incoming api calls
+              port: 8080
+              # -- path for incoming api calls
+              path: /BPNL000000000000/api
+            # -- data management api, used by internal users, can be added to an ingress and must not be internet facing
+            management:
+              # -- port for incoming api calls
+              port: 8081
+              # -- path for incoming api calls
+              path: /BPNL000000000000/management
+              # -- authentication key, must be attached to each 'X-Api-Key' request header
+              authKey: password
+            # -- control api, used for internal control calls. can be added to the internal ingress, but should probably not
+            control:
+              # -- port for incoming api calls
+              port: 8083
+              # -- path for incoming api calls
+              path: /BPNL000000000000/control
+            # -- ids api, used for inter connector communication and must be internet facing
+            protocol:
+              # -- port for incoming api calls
+              port: 8084
+              # -- path for incoming api calls
+              path: /BPNL000000000000/api/v1/dsp
+            # -- metrics api, used for application metrics, must not be internet facing
+            metrics:
+              # -- port for incoming api calls
+              port: 9090
+              # -- path for incoming api calls
+              path: /BPNL000000000000/metrics
+            # -- observability api with unsecured access, must not be internet facing
+            observability:
+              # -- port for incoming API calls
+              port: 8085
+              # -- observability api, provides /health /readiness and /liveness endpoints
+              path: /BPNL000000000000/observability
+              # -- allow or disallow insecure access, i.e. access without authentication
+              insecure: true
+
+          ssi:
+            miw:
+              url: "https://managed-identity-wallets-new-23-12.stable.demo.catena-x.net"
+              authorityId: "BPNL00000003CRHK"
+            oauth:
+              tokenurl: "https://centralidp-23-12.stable.demo.catena-x.net/auth/realms/CX-Central/protocol/openid-connect/token"
+              client:
+                id: "sa3"
+                secretAlias: "stable-client-secret"
+            endpoint:
+              audience: https://materialpass-23-12.stable.demo.catena-x.net/consumer
+
+          ## Ingress declaration to expose the network service.
+          ingresses:
+            ## Public / Internet facing Ingress
+            - enabled: true
+              # -- The hostname to be used to precisely map incoming traffic onto the underlying network service
+              hostname: "materialpass-23-12.stable.demo.catena-x.net"
+              # -- Additional ingress annotations to add
+              annotations: {}
+              # -- EDC endpoints exposed by this ingress resource
+              endpoints:
+                - default
+                - management
+                - control
+                - protocol
+                - metrics
+                - observability
+              # -- Defines the [ingress class](https://kubernetes.io/docs/concepts/services-networking/ingress/#ingress-class)  to use
+              className: "nginx"
+              # -- TLS [tls class](https://kubernetes.io/docs/concepts/services-networking/ingress/#tls) applied to the ingress resource
+              tls:
+                # -- Enables TLS on the ingress resource
+                enabled: true
+                # -- If present overwrites the default secret name
+                secretName: "tls-secret"
+        dataplane:
+          enabled: true
+          endpoints:
+            default:
+              port: 8080
+              path: /BPNL000000000000/api
+            public:
+              port: 8081
+              path: /BPNL000000000000/api/public
+            control:
+              port: 8083
+              path: /BPNL000000000000/api/dataplane/control
+            proxy:
+              port: 8186
+              path: /BPNL000000000000/proxy
+            observability:
+              # -- port for incoming API calls
+              port: 8085
+              # -- observability api, provides /health /readiness and /liveness endpoints
+              path: /BPNL000000000000/observability
+              # -- allow or disallow insecure access, i.e. access without authentication
+              insecure: true
+            metrics:
+              port: 9090
+              path: /BPNL000000000000/metrics
+
+          ## Ingress declaration to expose the network service.
+          ingresses:
+            ## Public / Internet facing Ingress
+            - enabled: true
+              # -- The hostname to be used to precisely map incoming traffic onto the underlying network service
+              hostname: "materialpass-23-12.stable.demo.catena-x.net"
+              # -- Additional ingress annotations to add
+              annotations: {}
+              # -- EDC endpoints exposed by this ingress resource
+              endpoints:
+                - public
+              # -- Defines the [ingress class](https://kubernetes.io/docs/concepts/services-networking/ingress/#ingress-class)  to use
+              className: "nginx"
+              # -- TLS [tls class](https://kubernetes.io/docs/concepts/services-networking/ingress/#tls) applied to the ingress resource
+              tls:
+                # -- Enables TLS on the ingress resource
+                enabled: true
+                # -- If present overwrites the default secret name
+                secretName: "tls-secret"
+              ## Adds [cert-manager](https://cert-manager.io/docs/) annotations to the ingress resource
+              certManager:
+                # -- If preset enables certificate generation via cert-manager namespace scoped issuer
+                issuer: ""
+                # -- If preset enables certificate generation via cert-manager cluster-wide issuer
+                clusterIssuer: ""
+
+        postgresql:
+          username: dpp_user
+          password: dpp_password
+
+
+        vault:
+          hashicorp:
+            url: https://vault.demo.catena-x.net
+            token: s.nMWRzBOSupUC5iXyANzHC7Zo
+            paths:
+              secret:  /v1/material-pass
+              health: /v1/sys/health
+          secretNames:
+            transferProxyTokenSignerPrivateKey: ids-daps_key
+            transferProxyTokenSignerPublicKey: ids-daps_crt
+            transferProxyTokenEncryptionAesKey: edc-encryption-key
+
+        backendService:
+            httpProxyTokenReceiverUrl: "https://materialpass-23-12.stable.demo.catena-x.net/endpoint"
+  syncPolicy:
+    syncOptions:
+      - Replace=true

--- a/stable/23.12/dpp-registry.yaml
+++ b/stable/23.12/dpp-registry.yaml
@@ -1,0 +1,63 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: dpp-registry
+  namespace: argocd
+spec:
+  project: project-material-pass
+  destination:
+    server: 'https://kubernetes.default.svc'
+    namespace: product-material-pass
+  source:
+    repoURL: 'https://eclipse-tractusx.github.io/charts/dev'
+    targetRevision: 0.3.15
+    chart: registry
+    helm:
+      values: >-
+        provider-dtr:
+          registry:
+            host: materialpass-23-12.stable.demo.catena-x.net
+            ## If 'authentication' is set to false, no OAuth authentication is enforced
+            authentication: false
+            # Issuer url for the dtr (resource server),
+            # make sure that the url points to an externally resolvable hostname.
+            # If no value is committed, and the integrated Keycloak is enabled,
+            # the K8s internal service name is used, which is a problem, when
+            # validating the issuer claim in an access token
+            idpIssuerUri: https://centralidp-23-12.stable.demo.catena-x.net/auth/realms/CX-Central
+            idpClientId: Cl13-CX-Battery
+            tenantId: default-tenant
+            dataSource:
+              driverClassName: org.postgresql.Driver
+              sqlInitPlatform: pg
+              ## The url, user, and password parameter will be ignored if 'enablePostgres' is set to true.
+              ## In that case the postgresql auth parameters are used.
+              url: jdbc:postgresql://registry:5432
+              user: default-user
+              password: password
+            ingress:
+              enabled: true
+              tls: true
+              urlPrefix: /semantics/registry
+              className: nginx
+              annotations:
+                # Add annotations for the ingress, e.g.:
+                cert-manager.io/cluster-issuer: selfsigned-cluster-issuer
+                nginx.ingress.kubernetes.io/rewrite-target: /$2
+                nginx.ingress.kubernetes.io/use-regex: "true"
+                nginx.ingress.kubernetes.io/enable-cors: "true"
+                nginx.ingress.kubernetes.io/cors-allow-credentials: "true"
+                nginx.ingress.kubernetes.io/x-forwarded-prefix: /semantics/registry
+
+            # enables the default postgres database
+            enablePostgres: true
+            # enables the default keycloak identity provider
+            # relies on a postgres instance
+            enableKeycloak: false
+
+          postgresql:
+            auth:
+              username: default-user
+              password: password
+              database: default-database
+

--- a/stable/23.12/ids-data-exchange-test-service.yaml
+++ b/stable/23.12/ids-data-exchange-test-service.yaml
@@ -1,0 +1,43 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: ids-data-exchange-test-service
+  namespace: argocd
+spec:
+  project: project-essential-services
+  destination:
+    server: 'https://kubernetes.default.svc'
+    namespace: product-essential-services
+  source:
+    repoURL: 'https://eclipse-tractusx.github.io/charts/dev'
+    targetRevision: 1.0.9
+    chart: data-exchange
+    helm:
+      parameters:
+        - name: dataex.secret.e2edetsurl
+          value: 'https://dataex-23-12.stable.demo.catena-x.net'
+        - name: dataex.secret.edcapikey
+          value: jzWterGZLGxMT4QbRBh4WLlyqlmmSXqXBLGiOkZlS0fYmQUpv7
+        - name: dataex.secret.edcapikeyheader
+          value: X-Api-Key
+        - name: dataex.secret.edchostname
+          value: 'https://tsyste-f783465e-us.local.cx.dih-cloud.com'
+      values: |-
+        ingress:
+          enabled: true
+          annotations:
+            nginx.ingress.kubernetes.io/use-regex: "true"
+            cert-manager.io/cluster-issuer: "letsencrypt-prod"
+          className: "nginx"
+          host: "dataex-23-12.stable.demo.catena-x.net"
+          hosts:
+            - host: dataex-23-12.stable.demo.catena-x.net
+              paths:
+                - path: /
+                  pathType: ImplementationSpecific
+
+          tls:
+            enabled: true
+            secretName: tls-secret
+            host: "dataex-23-12.stable.demo.catena-x.net"
+

--- a/stable/23.12/ids-sdf.yaml
+++ b/stable/23.12/ids-sdf.yaml
@@ -1,0 +1,79 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: ids-sdf
+  namespace: argocd
+spec:
+  project: project-essential-services
+  destination:
+    server: 'https://kubernetes.default.svc'
+    namespace: product-essential-services
+  source:
+    repoURL: 'https://eclipse-tractusx.github.io/charts/dev'
+    targetRevision: 2.1.7
+    chart: sdfactory
+    helm:
+      parameters:
+        - name: sdfactory.secret.authServerUrl
+          value: 'https://centralidp-23-12.stable.demo.catena-x.net/auth'
+        - name: sdfactory.secret.clearingHouseClientId
+          value: dih-sa-test-catena-stable-7b66553047a0
+        - name: sdfactory.secret.clearingHouseClientSecret
+          value: 8aNJ59EyO9U1OT92IsAvb8t8IRSmNqKQ
+        - name: sdfactory.secret.clearingHouseRealm
+          value: carla
+        - name: sdfactory.secret.clearingHouseServerUrl
+          value: 'https://iam.test.dih-cloud.com'
+        - name: sdfactory.secret.clearingHouseUri
+          value: 'https://validation.test.dih-cloud.com/api/v1/compliance'
+        - name: sdfactory.secret.clientId
+          value: sa-cl5-custodian-1
+        - name: sdfactory.secret.clientSecret
+          value: hKE1KjZV3UprSsGDXUkgfyqpp8KxQwKm
+        - name: sdfactory.secret.custodianWalletUri
+          value: 'https://managed-identity-wallets-new-23-12.stable.demo.catena-x.net/api'
+        - name: sdfactory.secret.jwkSetUri
+          value: >-
+            https://centralidp-23-12.stable.demo.catena-x.net/auth/realms/CX-Central/protocol/openid-connect/certs
+        - name: sdfactory.secret.realm
+          value: CX-Central
+        - name: sdfactory.secret.resource
+          value: Cl2-CX-Portal
+      values: |-
+        ingress:
+          enabled: true
+          className: "nginx"
+          issuer: "letsencrypt-prod"
+          domain: ""
+          annotations:
+            cert-manager.io/cluster-issuer: letsencrypt-prod
+            kubernetes.io/ingress.class: nginx
+            nginx.ingress.kubernetes.io/configuration-snippet: |-
+              if ($http_origin ~* "http.?:\/\/(.*\.)?(localhost:3000|catena-x\.net|example\.com|idses-fe\.demo\.catena-x\.net).*$") {
+                set $allow_origin $http_origin;
+              }
+
+              add_header "Access-Control-Allow-Origin" "$http_origin" always;
+              add_header "Access-Control-Allow-Methods" "GET, PUT, POST, OPTIONS, DELETE" always;
+              add_header "Access-Control-Allow-Headers" "DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Authorization" always;
+              add_header "Access-Control-Expose-Headers" "Content-Range";
+
+              if ($request_method = 'OPTIONS') {
+                add_header "Access-Control-Allow-Origin" "$http_origin" always;
+                add_header "Access-Control-Allow-Methods" "GET, PUT, POST, OPTIONS, DELETE" always;
+                add_header "Access-Control-Allow-Headers" "DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Authorization" always;
+                add_header "Access-Control-Max-Age" "1728000" always;
+                add_header "Content-Type" "text/plain charset=UTF-8";
+                add_header "Content-Length" 0;
+                return 204;
+              }
+
+          hosts:
+            - host: "sdfactory-23-12.stable.demo.catena-x.net"
+              paths:
+                - path: /
+                  pathType: Prefix
+          tls:
+            - tlsName: sdfactory-23-12.stable.demo.catena-x.net-tls
+              hosts:
+                - sdfactory-23-12.stable.demo.catena-x.net

--- a/stable/23.12/managed-identity-wallet.yaml
+++ b/stable/23.12/managed-identity-wallet.yaml
@@ -1,0 +1,51 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: managed-identity-wallet
+  namespace: argocd
+spec:
+  project: project-managed-identity-wallets
+  destination:
+    server: 'https://kubernetes.default.svc'
+    namespace: product-managed-identity-wallets
+  source:
+    repoURL: 'https://eclipse-tractusx.github.io/charts/dev'
+    targetRevision: 0.1.0-rc.3
+    chart: managed-identity-wallet
+    helm:
+      parameters:
+        - name: keycloak.enabled
+          value: 'false'
+        - name: ingress.enabled
+          value: 'true'
+        - name: miw.host
+          value: managed-identity-wallets-new-23-12.stable.demo.catena-x.net
+        - name: miw.authorityWallet.bpn
+          value: BPNL00000003CRHK
+        - name: miw.keycloak.realm
+          value: CX-Central
+        - name: miw.database.name
+          value: miw
+        - name: miw.database.user
+          value: miw
+        - name: postgresql.auth.database
+          value: miw
+        - name: miw.keycloak.clientId
+          value: Cl5-CX-Custodian
+        - name: miw.keycloak.url
+          value: 'https://centralidp-23-12.stable.demo.catena-x.net/auth'
+        - name: image.tag
+          value: 0.2.0
+        - name: miw.ssi.enforceHttpsInDidWebResolution
+          value: 'true'
+      values: |-
+        ingress:
+          hosts:
+            - host: 'managed-identity-wallets-new-23-12.stable.demo.catena-x.net'
+              paths:
+                - path: /
+                  pathType: ImplementationSpecific
+          tls:
+            - secretName: ingress-secret
+              hosts:
+                - 'managed-identity-wallets-new-23-12.stable.demo.catena-x.net'

--- a/stable/23.12/portal-pgadmin4.yaml
+++ b/stable/23.12/portal-pgadmin4.yaml
@@ -1,0 +1,37 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: portal-pgadmin4
+  namespace: argocd
+spec:
+  project: project-portal
+  destination:
+    server: 'https://kubernetes.default.svc'
+    namespace: product-portal
+  source:
+    repoURL: 'https://github.com/catenax-ng/product-portal-tools.git'
+    path: charts/pgadmin4
+    targetRevision: main
+    plugin:
+      env:
+        - name: HELM_VALUES
+          value: |
+            pgadmin4:
+              secret:
+                password: "<path:portal/data/stable/pgadmin4#password>"
+              env:
+                email: portal@catena-x.net
+              existingSecret: secret-pgadmin4
+              ingress:
+                enabled: true
+                ingressClassName: "nginx"
+                annotations:
+                hosts:
+                  - host: portal-pgadmin4-23-12.stable.demo.catena-x.net
+                    paths:
+                    - path: /
+                      pathType: Prefix
+                tls:
+                  - hosts:
+                    - portal-pgadmin4-23-12.stable.demo.catena-x.net
+                    secretName: tls-secret

--- a/stable/23.12/portal.yaml
+++ b/stable/23.12/portal.yaml
@@ -1,0 +1,232 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: portal
+  namespace: argocd
+spec:
+  project: project-portal
+  destination:
+    server: 'https://kubernetes.default.svc'
+    namespace: product-portal
+  source:
+    repoURL: 'https://eclipse-tractusx.github.io/charts/dev'
+    targetRevision: 1.6.0
+    chart: portal
+    plugin:
+      env:
+        - name: HELM_VALUES
+          value: >
+            portalAddress: "https://portal-23-12.stable.demo.catena-x.net"
+            portalBackendAddress: "https://portal-backend-23-12.stable.demo.catena-x.net"
+            centralidpAddress: "https://centralidp-23-12.stable.demo.catena-x.net"
+            sharedidpAddress: "https://sharedidp-23-12.stable.demo.catena-x.net"
+            semanticsAddress: "https://semantics-23-12.stable.demo.catena-x.net"
+            bpdmPartnersPoolAddress: "https://business-partners-23-12.stable.demo.catena-x.net"
+            bpdmPortalGateAddress: "https://business-partners-23-12.stable.demo.catena-x.net"
+            custodianAddress: "https://managed-identity-wallets-new-23-12.stable.demo.catena-x.net"
+            sdfactoryAddress: "https://sdfactory-23-12.stable.demo.catena-x.net"
+            clearinghouseAddress: "https://validation.test.dih-cloud.com"
+            clearinghouseTokenAddress: "https://iam.test.dih-cloud.com/realms/carla/protocol/openid-connect/token"
+
+            frontend:
+              ingress:
+                enabled: true
+                annotations:
+                  kubernetes.io/ingress.class: "nginx"
+                  nginx.ingress.kubernetes.io/rewrite-target: "/$$1"
+                  nginx.ingress.kubernetes.io/use-regex: "true"
+                  nginx.ingress.kubernetes.io/enable-cors: "true"
+                  nginx.ingress.kubernetes.io/cors-allow-origin: "http://localhost:3000, https://*-23-12.stable.demo.catena-x.net"
+                tls:
+                  - secretName: "tls-secret"
+                    hosts:
+                      - "portal-23-12.stable.demo.catena-x.net"
+                hosts:
+                  - host: "portal-23-12.stable.demo.catena-x.net"
+                    paths:
+                      - path: "/(.*)"
+                        pathType: "Prefix"
+                        backend:
+                          service: "portal"
+                          port: 8080
+                      - path: "/registration/(.*)"
+                        pathType: "Prefix"
+                        backend:
+                          service: "registration"
+                          port: 8080
+                      - path: "/((assets|documentation)/.*)"
+                        pathType: "Prefix"
+                        backend:
+                          service: "assets"
+                          port: 8080
+            backend:
+              ingress:
+                enabled: true
+                annotations:
+                  kubernetes.io/ingress.class: "nginx"
+                  nginx.ingress.kubernetes.io/use-regex: "true"
+                  nginx.ingress.kubernetes.io/enable-cors: "true"
+                  nginx.ingress.kubernetes.io/proxy-body-size: "8m"
+                  nginx.ingress.kubernetes.io/cors-allow-origin: "http://localhost:3000, https://*-23-12.stable.demo.catena-x.net"
+                tls:
+                  - secretName: "tls-secret"
+                    hosts:
+                      - "portal-backend-23-12.stable.demo.catena-x.net"
+                hosts:
+                  - host: "portal-backend-23-12.stable.demo.catena-x.net"
+                    paths:
+                      - path: "/api/registration"
+                        pathType: "Prefix"
+                        backend:
+                          service: "registration-service"
+                          port: 8080
+                      - path: "/api/administration"
+                        pathType: "Prefix"
+                        backend:
+                          service: "administration-service"
+                          port: 8080
+                      - path: "/api/notification"
+                        pathType: "Prefix"
+                        backend:
+                          service: "notification-service"
+                          port: 8080
+                      - path: "/api/apps"
+                        pathType: "Prefix"
+                        backend:
+                          service: "marketplace-app-service"
+                          port: 8080
+                      - path: "/api/services"
+                        pathType: "Prefix"
+                        backend:
+                          service: "services-service"
+                          port: 8080
+              keycloak:
+                central:
+                  clientId: "<path:portal/data/keycloak#central-client-id>"
+                  clientSecret: "<path:portal/data/stable/keycloak#central-client-secret>"
+                  dbConnection:
+                    password: "<path:portal/data/stable/keycloak#central-db-password>"
+                shared:
+                  clientId: "<path:portal/data/keycloak#shared-client-id>"
+                  clientSecret: "<path:portal/data/stable/keycloak#shared-client-secret>"
+              mailing:
+                host: "<path:portal/data/mailing#host>"
+                port: "<path:portal/data/mailing#port>"
+                user: "<path:portal/data/mailing#user>"
+                password: "<path:portal/data/mailing#password>"
+              registration:
+                logging:
+                  default: "Debug"
+                  bpdmLibrary: "Debug"
+                  registrationService: "Debug"
+                healthChecks:
+                  startup:
+                    tags:
+                    - name: "HEALTHCHECKS__0__TAGS__0"
+                      value: "keycloak"
+                    - name: "HEALTHCHECKS__0__TAGS__1"
+                      value: "portaldb"
+                swaggerEnabled: true
+              administration:
+                logging:
+                  default: "Debug"
+                  businessLogic: "Debug"
+                  sdfactoryLibrary: "Debug"
+                  bpdmLibrary: "Debug"
+                  custodianLibrary: "Debug"
+                healthChecks:
+                  startup:
+                    tags:
+                    - name: "HEALTHCHECKS__0__TAGS__0"
+                      value: "keycloak"
+                    - name: "HEALTHCHECKS__0__TAGS__1"
+                      value: "portaldb"
+                    - name: "HEALTHCHECKS__0__TAGS__2"
+                      value: "provisioningdb"
+                swaggerEnabled: true
+              provisioning:
+                sharedRealm:
+                  smtpServer:
+                    host: "<path:portal/data/mailing#host>"
+                    port: "<path:portal/data/mailing#port>"
+                    user: "<path:portal/data/mailing#user>"
+                    password: "<path:portal/data/mailing#password>"
+                    from: "<path:portal/data/mailing#from>"
+                    replyTo: "<path:portal/data/mailing#replyto>"
+              appmarketplace:
+                logging:
+                  default: "Debug"
+                  offersLibrary: "Debug"
+                healthChecks:
+                  startup:
+                    tags:
+                    - name: "HEALTHCHECKS__0__TAGS__0"
+                      value: "keycloak"
+                    - name: "HEALTHCHECKS__0__TAGS__1"
+                      value: "portaldb"
+                swaggerEnabled: true
+              portalmigrations:
+                logging:
+                  default: "Debug"
+                seeding:
+                  testDataEnvironments: "consortia"
+              notification:
+                healthChecks:
+                  startup:
+                    tags:
+                    - name: "HEALTHCHECKS__0__TAGS__0"
+                      value: "keycloak"
+                    - name: "HEALTHCHECKS__0__TAGS__1"
+                      value: "portaldb"
+                logging:
+                  default: "Debug"
+                swaggerEnabled: true
+              services:
+                logging:
+                  default: "Debug"
+                  offersLibrary: "Debug"
+                healthChecks:
+                  startup:
+                    tags:
+                    - name: "HEALTHCHECKS__0__TAGS__0"
+                      value: "keycloak"
+                    - name: "HEALTHCHECKS__0__TAGS__1"
+                      value: "portaldb"
+                swaggerEnabled: true
+              processesworker:
+                logging:
+                  default: "Debug"
+                  processesLibrary: "Debug"
+                  bpdmLibrary: "Debug"
+                  clearinghouseLibrary: "Debug"
+                  custodianLibrary: "Debug"
+                  sdfactoryLibrary: "Debug"
+                  offerProvider: "Debug"
+                bpdm:
+                  clientId: "<path:portal/data/processes-worker#bpdm-client-id>"
+                  clientSecret: "<path:portal/data/stable/processes-worker#bpdm-client-secret>"
+                clearinghouse:
+                  clientId: "<path:portal/data/stable/processes-worker#clearinghouse-client-id>"
+                  clientSecret: "<path:portal/data/stable/processes-worker#clearinghouse-client-secret>"
+                custodian:
+                  clientId: "<path:portal/data/processes-worker#custodian-client-id>"
+                  clientSecret: "<path:portal/data/stable/processes-worker#custodian-client-secret>"
+                sdfactory:
+                  issuerBpn: "BPNL00000003CRHK"
+                  clientId: "<path:portal/data/processes-worker#sdfactory-client-id>"
+                  clientSecret: "<path:portal/data/stable/processes-worker#sdfactory-client-secret>"
+                offerprovider:
+                  clientId: "<path:portal/data/processes-worker#offerprovider-client-id>"
+                  clientSecret: "<path:portal/data/stable/processes-worker#offerprovider-client-secret>"
+            postgresql:
+              auth:
+                password: "<path:portal/data/stable/postgres#postgres-password>"
+                replicationPassword: "<path:portal/data/stable/postgres#replication-password>"
+                portalPassword: "<path:portal/data/stable/postgres#portal-password>"
+                provisioningPassword: "<path:portal/data/stable/postgres#provisioning-password>"
+              primary:
+                extendedConfiguration: |
+                  max_connections = 200
+              readReplicas:
+                extendedConfiguration: |
+                  max_connections = 200

--- a/stable/23.12/provider-agent.yaml
+++ b/stable/23.12/provider-agent.yaml
@@ -1,0 +1,30 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: provider-agent
+  namespace: argocd
+spec:
+  project: project-knowledge
+  destination:
+    server: 'https://kubernetes.default.svc'
+    namespace: product-knowledge
+  source:
+    repoURL: 'https://eclipse-tractusx.github.io/charts/dev'
+    targetRevision: 1.9.8
+    chart: provisioning-agent
+    helm:
+      parameters:
+        - name: securityContext.readOnlyRootFilesystem
+          value: 'false'
+        - name: securityContext.runAsUser
+          value: '999'
+        - name: securityContext.runAsGroup
+          value: '999'
+        - name: podSecurityContext.runAsUser
+          value: '999'
+        - name: podSecurityContext.runAsGroup
+          value: '999'
+        - name: podSecurityContext.fsGroup
+          value: '999'
+        - name: bindings.dtc.mappping
+          value: "[PrefixDeclaration]\ncx-common:          https://w3id.org/catenax/ontology/common#\ncx-core:            https://w3id.org/catenax/ontology/core#\ncx-vehicle:         https://w3id.org/catenax/ontology/vehicle#\ncx-reliability:     https://w3id.org/catenax/ontology/reliability#\nuuid:\t\t        urn:uuid:\nbpnl:\t\t        bpn:legal:\nowl:\t\t        http://www.w3.org/2002/07/owl#\nrdf:\t\t        http://www.w3.org/1999/02/22-rdf-syntax-ns#\nxml:\t\t        http://www.w3.org/XML/1998/namespace\nxsd:\t\t        http://www.w3.org/2001/XMLSchema#\njson:               https://json-schema.org/draft/2020-12/schema#\nobda:\t\t        https://w3id.org/obda/vocabulary#\nrdfs:\t\t        http://www.w3.org/2000/01/rdf-schema#\noem:                urn:oem:\n\n[MappingDeclaration] @collection [[\nmappingId\tdtc-meta\ntarget\t\tbpnl:{bpnl} rdf:type cx-common:BusinessPartner ; cx-core:id {bpnl}^^xsd:string . \nsource\t\tSELECT distinct \"bpnl\" FROM \"dtc\".\"meta\"\n\nmappingId\tdtc-content\ntarget\t\toem:Analysis/{id} rdf:type cx-reliability:Analysis ; cx-core:id {code}^^xsd:string ; cx-core:name {description}^^xsd:string .\nsource\t\tSELECT * FROM \"dtc\".\"content\"\n\nmappingId\tdtc-part\ntarget\t\toem:Part/{entityGuid} rdf:type cx-vehicle:Part ; cx-core:id {enDenomination}^^xsd:string ; cx-core:name {classification}^^xsd:string .\nsource\t\tSELECT * FROM \"dtc\".\"part\"\n\nmappingId\tdtc-meta-part\ntarget\t\toem:Part/{entityGuid} cx-vehicle:manufacturer bpnl:{bpnl}. \nsource\t\tSELECT \"bpnl\",\"entityGuid\" FROM \"dtc\".\"part\"\n\nmappingId\tdtc-part-content\ntarget\t\toem:Analysis/{dtc_id} cx-reliability:analysedObject oem:Part/{part_entityGuid}. \nsource\t\tSELECT \"part_entityGuid\",\"dtc_id\" FROM \"dtc\".\"content_part\"\n\n]]\n"

--- a/stable/23.12/remoting-agent.yaml
+++ b/stable/23.12/remoting-agent.yaml
@@ -1,0 +1,18 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: remoting-agent
+  namespace: argocd
+spec:
+  project: project-knowledge
+  destination:
+    server: 'https://kubernetes.default.svc'
+    namespace: product-knowledge
+  source:
+    repoURL: 'https://eclipse-tractusx.github.io/charts/dev'
+    targetRevision: 1.9.8
+    chart: remoting-agent
+    helm:
+      parameters:
+        - name: image.pullPolicy
+          value: Always

--- a/stable/23.12/semantic-services.yaml
+++ b/stable/23.12/semantic-services.yaml
@@ -1,0 +1,69 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: semantic-services
+  namespace: argocd
+spec:
+  project: project-semantics
+  destination:
+    server: 'https://kubernetes.default.svc'
+    namespace: product-semantics
+  source:
+    repoURL: 'https://eclipse-tractusx.github.io/charts/dev'
+    targetRevision: 0.1.29
+    chart: semantic-hub
+    plugin:
+      env:
+        - name: HELM_VALUES
+          value: |
+            hub:
+              enableKeycloak: false
+              imagePullPolicy: Always
+              replicaCount: 1
+              containerPort: 4242
+              ## Use in-memory triple store that is not persistent
+              embeddedTripleStore: false
+              host: semantics-23-12.stable.demo.catena-x.net
+              ## If 'authentication' is set to false, no OAuth authentication is enforced
+              authentication: true
+              idpIssuerUri: https://centralidp-23-12.stable.demo.catena-x.net/auth/realms/CX-Central
+              idpClientId: Cl3-CX-Semantic
+              ## Ignored if 'graphdb.enabled' is set to true
+              graphdbBaseUrl: http://graphdb:3030
+              service:
+                port: 8080
+                type: ClusterIP
+              ingress:
+                ## Enable ingress for the Semantic Hub
+                enabled: true
+                ## Enable TLS (e.g. by using cert-manager)
+                tls: true
+                ## The secret name that contains the necessary 'tls.crt' and 'tls.key' entries
+                ## When using cert-manager this secret is created automatically
+                urlPrefix: /hub
+                tlsSecretName: hub-certificate-secret
+                className: nginx
+                annotations:
+                  cert-manager.io/cluster-issuer: letsencrypt-prod
+                  nginx.ingress.kubernetes.io/rewrite-target: /$$2
+                  nginx.ingress.kubernetes.io/use-regex: "true"
+                  nginx.ingress.kubernetes.io/enable-cors: "true"
+                  nginx.ingress.kubernetes.io/cors-allow-credentials: "true"
+                  nginx.ingress.kubernetes.io/x-forwarded-prefix: /hub
+            graphdb:
+              ## Include Fuski deployment or deploy separately
+              enabled: true
+              image: ghcr.io/catenax-ng/jena-fuseki:4.7.0
+              storageClassName: azurefile
+              pvcAccessModes:
+                - ReadWriteOnce
+              resources:
+                limits:
+                  memory: "1024Mi"
+                requests:
+                  memory: "512Mi"
+              service:
+                port: 3030
+            enableKeycloak: false
+            keycloak:
+              enabled: false

--- a/stable/23.12/sharedidp.yaml
+++ b/stable/23.12/sharedidp.yaml
@@ -1,0 +1,100 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: sharedidp
+  namespace: argocd
+spec:
+  project: project-portal
+  destination:
+    server: 'https://kubernetes.default.svc'
+    namespace: product-portal
+  source:
+    repoURL: 'https://eclipse-tractusx.github.io/charts/dev'
+    targetRevision: 1.2.0
+    chart: sharedidp
+    plugin:
+      env:
+        - name: HELM_VALUES
+          value: |
+            keycloak:
+              extraVolumes:
+                - name: themes-catenax-shared
+                  emptyDir: {}
+                - name: themes-catenax-shared-portal
+                  emptyDir: {}
+                - name: realms
+                  emptyDir: {}
+                - name: realm-secrets
+                  secret:
+                    secretName: secret-sharedidp-realms
+              extraVolumeMounts:
+                - name: themes-catenax-shared
+                  mountPath: "/opt/bitnami/keycloak/themes/catenax-shared"
+                - name: themes-catenax-shared-portal
+                  mountPath: "/opt/bitnami/keycloak/themes/catenax-shared-portal"
+                - name: realms
+                  mountPath: "/realms"
+                - name: realm-secrets
+                  mountPath: "/secrets"
+              initContainers:
+                - name: import
+                  image: tractusx/portal-iam-consortia:v1.2.0
+                  imagePullPolicy: Always
+                  command:
+                    - sh
+                  args:
+                    - -c
+                    - |
+                      echo "Copying themes-catenax-shared..."
+                      cp -R /import/themes/catenax-shared/* /themes-catenax-shared
+                      echo "Copying themes-catenax-shared-portal..."
+                      cp -R /import/themes/catenax-shared-portal/* /themes-catenax-shared-portal
+                      echo "Copying realms..."
+                      cp -R /import/catenax-shared/stable/realms/* /realms
+                      echo "Copying realms-secrets..."
+                      cp /secrets/* /realms
+                  volumeMounts:
+                  - name: themes-catenax-shared
+                    mountPath: "/themes-catenax-shared"
+                  - name: themes-catenax-shared-portal
+                    mountPath: "/themes-catenax-shared-portal"
+                  - name: realms
+                    mountPath: "/realms"
+                  - name: realm-secrets
+                    mountPath: "/secrets"
+              ingress:
+                enabled: true
+                ingressClassName: nginx
+                hostname: sharedidp-23-12.stable.demo.catena-x.net
+                annotations:
+                  cert-manager.io/cluster-issuer: letsencrypt-prod
+                  nginx.ingress.kubernetes.io/cors-allow-credentials: "true"
+                  nginx.ingress.kubernetes.io/cors-allow-methods: PUT, GET, POST, OPTIONS
+                  nginx.ingress.kubernetes.io/cors-allow-origin: https://sharedidp-23-12.stable.demo.catena-x.net, http://localhost:3000
+                  nginx.ingress.kubernetes.io/enable-cors: "true"
+                  nginx.ingress.kubernetes.io/proxy-buffer-size: 128k
+                  nginx.ingress.kubernetes.io/proxy-buffering: "on"
+                  nginx.ingress.kubernetes.io/proxy-buffers-number: "20"
+                  nginx.ingress.kubernetes.io/use-regex: "true"
+                tls: true
+            secrets:
+              auth:
+                existingSecret:
+                  adminpassword: "<path:portal/data/stable/iam/sharedidp-keycloak#admin-password>"
+                  managementpassword: "<path:portal/data/stable/iam/sharedidp-keycloak#management-password>"
+              postgresql:
+                auth:
+                  existingSecret:
+                    postgrespassword: "<path:portal/data/stable/iam/sharedidp-postgres#postgres-password>"
+                    password: "<path:portal/data/stable/iam/sharedidp-postgres#password>"
+                    replicationPassword: "<path:portal/data/stable/iam/sharedidp-postgres#replication-password>"
+              realmuser:
+                enabled: true
+                cxtestaccessuser: "<path:portal/data/iam/sharedidp-user#CX-Test-Access-users-0.json>"
+                company1user: "<path:portal/data/iam/sharedidp-user#Company-1-users-0.json>"
+                company2user: "<path:portal/data/iam/sharedidp-user#Company-2-users-0.json>"
+                securitycompany: "<path:portal/data/iam/sharedidp-user#Security-Company-users-0.json>"
+                cxoperator: "<path:portal/data/iam/sharedidp-user#CX-Operator-users-0.json>"
+                serviceprovider: "<path:portal/data/iam/sharedidp-user#Service-Provider-users-0.json>"
+                appprovider: "<path:portal/data/iam/sharedidp-user#App-Provider-users-0.json>"
+                chart: sharedidp

--- a/stable/23.12/tx-dt-registry-stable-a.yaml
+++ b/stable/23.12/tx-dt-registry-stable-a.yaml
@@ -1,0 +1,34 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: tx-dt-registry-stable-a
+  namespace: argocd
+spec:
+  project: project-traceability-foss
+  destination:
+    server: 'https://kubernetes.default.svc'
+    namespace: product-traceability-foss
+  source:
+    repoURL: 'https://eclipse-tractusx.github.io/charts/dev'
+    targetRevision: 0.3.22
+    chart: registry
+    helm:
+      parameters:
+        - name: enableKeycloak
+          value: 'false'
+      values: |
+        registry:
+          authentication: false
+          idpIssuerUri: https://centralidp-23-12.stable.demo.catena-x.net/auth/realms/CX-Central
+          host: trace-x-registry-stable-a-23-12.stable.demo.catena-x.net
+          ingress:
+            enabled: true
+            tls: true
+            className: nginx
+            urlPrefix: /semantics/registry
+            annotations:
+              nginx.ingress.kubernetes.io/enable-cors: "true"
+              nginx.ingress.kubernetes.io/cors-allow-credentials: "true"
+              nginx.ingress.kubernetes.io/rewrite-target: /$2
+              nginx.ingress.kubernetes.io/use-regex: "true"
+

--- a/stable/23.12/tx-dt-registry-stable-b.yaml
+++ b/stable/23.12/tx-dt-registry-stable-b.yaml
@@ -1,0 +1,34 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: tx-dt-registry-stable-b
+  namespace: argocd
+spec:
+  project: project-traceability-foss
+  destination:
+    server: 'https://kubernetes.default.svc'
+    namespace: product-traceability-foss
+  source:
+    repoURL: 'https://eclipse-tractusx.github.io/charts/dev'
+    targetRevision: 0.3.22
+    chart: registry
+    helm:
+      parameters:
+        - name: enableKeycloak
+          value: 'false'
+      values: |
+        registry:
+          authentication: false
+          idpIssuerUri: https://centralidp-23-12.stable.demo.catena-x.net/auth/realms/CX-Central
+          host: trace-x-registry-stable-b-23-12.stable.demo.catena-x.net
+          ingress:
+            enabled: true
+            tls: true
+            className: nginx
+            urlPrefix: /semantics/registry
+            annotations:
+              nginx.ingress.kubernetes.io/enable-cors: "true"
+              nginx.ingress.kubernetes.io/cors-allow-credentials: "true"
+              nginx.ingress.kubernetes.io/rewrite-target: /$2
+              nginx.ingress.kubernetes.io/use-regex: "true"
+

--- a/stable/23.12/tx-edc-provider-stable-a.yaml
+++ b/stable/23.12/tx-edc-provider-stable-a.yaml
@@ -1,0 +1,109 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: tx-edc-provider-stable-a
+  namespace: argocd
+spec:
+  project: project-traceability-foss
+  destination:
+    server: 'https://kubernetes.default.svc'
+    namespace: product-traceability-foss
+  source:
+    repoURL: 'https://eclipse-tractusx.github.io/charts/dev'
+    targetRevision: 0.5.0
+    chart: tractusx-connector
+    plugin:
+      env:
+        - name: HELM_VALUES
+          value: |
+            install:
+              postgresql: true
+              vault: false
+            enabled: true
+            nameOverride: "tx-edc-provider-stable-a"
+            fullnameOverride: "tx-edc-provider-stable-a"
+            participant:
+              id: BPNL00000003CML1
+            controlplane:
+              ingresses:
+                - enabled: true
+                  hostname: "trace-x-edc-stable-a-23-12.stable.demo.catena-x.net"
+                  annotations:
+                    nginx.ingress.kubernetes.io/ssl-passthrough: "false"
+                    nginx.ingress.kubernetes.io/backend-protocol: "HTTP"
+                    nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
+                  endpoints:
+                    - protocol
+                    - management
+                  tls:
+                    enabled: true
+                    secretName: tls-secret
+              ssi:
+                miw:
+                  url: '<path:traceability-foss/data/stable-a/edc/wallet#ssi.miw.url>'
+                  authorityId: '<path:traceability-foss/data/stable-a/edc/wallet#ssi.miw.authorityId>'
+                oauth:
+                  tokenurl: '<path:traceability-foss/data/stable-a/edc/wallet#ssi.oauth.tokenurl>'
+                  client:
+                    id: '<path:traceability-foss/data/stable-a/edc/wallet#ssi.oauth.client.id>'
+                    secretAlias: edc-miw-keycloak-secret-stable-a
+              endpoints:
+                management:
+                  authKey: '<path:traceability-foss/data/stable-a/edc/controlplane#edc.api.control.auth.apikey.value>'
+              resources:
+                limits:
+                  cpu: 400m
+                  memory: 1.5Gi
+                requests:
+                  cpu: 200m
+                  memory: 1.5Gi
+            dataplane:
+              ingresses:
+                - enabled: true
+                  hostname: "trace-x-edc-stable-a-dataplane-23-12.stable.demo.catena-x.net"
+                  annotations:
+                    nginx.ingress.kubernetes.io/ssl-passthrough: "false"
+                    nginx.ingress.kubernetes.io/backend-protocol: "HTTP"
+                    nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
+                  endpoints:
+                    - public
+                  className: "nginx"
+                  tls:
+                    enabled: true
+                    secretName: tls-secret
+
+              resources:
+                limits:
+                  cpu: 200m
+                  memory: 512Mi
+                requests:
+                  cpu: 100m
+                  memory: 512Mi
+
+            backendService:
+              httpProxyTokenReceiverUrl: "https://traceability-stable-a-23-12.stable.demo.catena-x.net/api/callback/endpoint-data-reference"
+
+            postgresql:
+              enabled: true
+              auth:
+                username: '<path:traceability-foss/data/stable-a/edc/database#user>'
+                password: '<path:traceability-foss/data/stable-a/edc/database#password>'
+              username: '<path:traceability-foss/data/stable-a/edc/database#user>'
+              password: '<path:traceability-foss/data/stable-a/edc/database#password>'
+              jdbcUrl: "jdbc:postgresql://{{ .Release.Name }}-postgresql:5432/edc"
+
+            vault:
+              hashicorp:
+                url: "https://vault.demo.catena-x.net"
+                token: '<path:traceability-foss/data/stable-a/edc#edc.vault.hashicorp.token>'
+                timeout: 30
+                healthCheck:
+                  enabled: true
+                  standbyOk: true
+                paths:
+                  secret: /v1/traceability-foss
+                  health: /v1/sys/health
+              secretNames:
+                transferProxyTokenSignerPrivateKey: daps-cert-key-stable-a
+                transferProxyTokenSignerPublicKey: daps-cert-stable-a
+                transferProxyTokenEncryptionAesKey: token-signer-aes-key

--- a/stable/23.12/tx-edc-provider-stable-b.yaml
+++ b/stable/23.12/tx-edc-provider-stable-b.yaml
@@ -1,0 +1,110 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: tx-edc-provider-stable-b
+  namespace: argocd
+spec:
+  project: project-traceability-foss
+  destination:
+    server: 'https://kubernetes.default.svc'
+    namespace: product-traceability-foss
+  source:
+    repoURL: 'https://eclipse-tractusx.github.io/charts/dev'
+    targetRevision: 0.5.0
+    chart: tractusx-connector
+    plugin:
+      env:
+        - name: HELM_VALUES
+          value: |
+            install:
+              postgresql: true
+              vault: false
+            enabled: true
+            nameOverride: "tx-edc-provider-stable-b"
+            fullnameOverride: "tx-edc-provider-stable-b"
+            participant:
+              id: BPNL00000003CNKC
+            controlplane:
+              ingresses:
+                - enabled: true
+                  hostname: "trace-x-edc-stable-b-23-12.stable.demo.catena-x.net"
+                  annotations:
+                    nginx.ingress.kubernetes.io/ssl-passthrough: "false"
+                    nginx.ingress.kubernetes.io/backend-protocol: "HTTP"
+                    nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
+                  endpoints:
+                    - protocol
+                    - management
+                  tls:
+                    enabled: true
+                    secretName: tls-secret
+              ssi:
+                miw:
+                  url: '<path:traceability-foss/data/stable-b/edc/wallet#ssi.miw.url>'
+                  authorityId: '<path:traceability-foss/data/stable-b/edc/wallet#ssi.miw.authorityId>'
+                oauth:
+                  tokenurl: '<path:traceability-foss/data/stable-b/edc/wallet#ssi.oauth.tokenurl>'
+                  client:
+                    id: '<path:traceability-foss/data/stable-b/edc/wallet#ssi.oauth.client.id>'
+                    secretAlias: edc-miw-keycloak-secret-stable-b
+              endpoints:
+                management:
+                  authKey: '<path:traceability-foss/data/stable-b/edc/controlplane#edc.api.control.auth.apikey.value>'
+              resources:
+                limits:
+                  cpu: 400m
+                  memory: 1.5Gi
+                requests:
+                  cpu: 200m
+                  memory: 1.5Gi
+            dataplane:
+              ingresses:
+                - enabled: true
+                  hostname: "trace-x-edc-stable-b-dataplane-23-12.stable.demo.catena-x.net"
+                  annotations:
+                    nginx.ingress.kubernetes.io/ssl-passthrough: "false"
+                    nginx.ingress.kubernetes.io/backend-protocol: "HTTP"
+                    nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
+                  endpoints:
+                    - public
+                  className: "nginx"
+                  tls:
+                    enabled: true
+                    secretName: tls-secret
+
+              resources:
+                limits:
+                  cpu: 200m
+                  memory: 512Mi
+                requests:
+                  cpu: 100m
+                  memory: 512Mi
+
+            backendService:
+              httpProxyTokenReceiverUrl: "https://traceability-stable-b-23-12.stable.demo.catena-x.net/api/callback/endpoint-data-reference"
+
+            postgresql:
+              enabled: true
+              auth:
+                username: '<path:traceability-foss/data/stable-b/edc/database#user>'
+                password: '<path:traceability-foss/data/stable-b/edc/database#password>'
+              username: '<path:traceability-foss/data/stable-b/edc/database#user>'
+              password: '<path:traceability-foss/data/stable-b/edc/database#password>'
+              jdbcUrl: "jdbc:postgresql://{{ .Release.Name }}-postgresql:5432/edc"
+
+            vault:
+              hashicorp:
+                url: "https://vault.demo.catena-x.net"
+                token: '<path:traceability-foss/data/stable-b/edc#edc.vault.hashicorp.token>'
+                timeout: 30
+                healthCheck:
+                  enabled: true
+                  standbyOk: true
+                paths:
+                  secret: /v1/traceability-foss
+                  health: /v1/sys/health
+              secretNames:
+                transferProxyTokenSignerPrivateKey: daps-cert-key-stable-b
+                transferProxyTokenSignerPublicKey: daps-cert-stable-b
+                transferProxyTokenEncryptionAesKey: token-signer-aes-key
+

--- a/stable/23.12/tx-stable-a.yaml
+++ b/stable/23.12/tx-stable-a.yaml
@@ -1,0 +1,375 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: tx-stable-a
+  namespace: argocd
+spec:
+  project: project-traceability-foss
+  destination:
+    server: 'https://kubernetes.default.svc'
+    namespace: product-traceability-foss
+  source:
+    repoURL: 'https://eclipse-tractusx.github.io/charts/dev'
+    targetRevision: 1.3.18
+    chart: traceability-foss
+    plugin:
+      env:
+        - name: HELM_VALUES
+          value: |
+            global:
+              enablePrometheus: false
+              enableGrafana: false
+            frontend:
+              image:
+                repository: ghcr.io/catenax-ng/tx-traceability-foss
+                tag: 6.0.1-rc4
+                CATENAX_PORTAL_API_URL: '<path:traceability-foss/data/stable-a/frontend#catenax_portal_api_url>'
+                CATENAX_PORTAL_KEYCLOAK_URL: '<path:traceability-foss/data/stable-a/frontend#catenax_portal_keycloak_url>'
+                CATENAX_PORTAL_BACKEND_DOMAIN: '<path:traceability-foss/data/stable-a/frontend#catenax_portal_backend_domain>'
+                CATENAX_PORTAL_URL: '<path:traceability-foss/data/stable-a/frontend#catenax_portal_url>'
+                CATENAX_PORTAL_CLIENT_ID: '<path:traceability-foss/data/stable-a/frontend#catenax_portal_client_id>'
+              nameOverride: "tx-frontend-stable-a"
+              fullnameOverride: "tx-frontend-stable-a"
+              ingress:
+                enabled: true
+                className: "nginx"
+                annotations:
+                  cert-manager.io/cluster-issuer: letsencrypt-prod
+                hosts:
+                  - host: "traceability-portal-stable-a-23-12.stable.demo.catena-x.net"
+                    paths:
+                      - path: /
+                        pathType: ImplementationSpecific
+                tls:
+                  - hosts:
+                      - "traceability-portal-stable-a-23-12.stable.demo.catena-x.net"
+                    secretName: "traceability-portal-stable-a-23-12.stable.demo.catena-x.net-tls"
+            backend:
+              image:
+                repository: ghcr.io/catenax-ng/tx-traceability-foss
+                tag: 6.0.1-rc4
+              nameOverride: "tx-backend-stable-a"
+              fullnameOverride: "tx-backend-stable-a"
+              podSecurityContext:
+                runAsUser: 10001
+                seccompProfile:
+                  type: RuntimeDefault
+              securityContext:
+                allowPrivilegeEscalation: false
+                runAsNonRoot: true
+                runAsUser: 10001
+                runAsGroup: 3000
+                capabilities:
+                  drop:
+                    - ALL
+                readOnlyRootFilesystem: false
+              resources:
+                limits:
+                  cpu: 500m
+                  memory: 512Mi
+                requests:
+                  cpu: 100m
+                  memory: 512Mi
+              springprofile: dev
+              ingress:
+                enabled: true
+                className: "nginx"
+                annotations:
+                  nginx.ingress.kubernetes.io/backend-protocol: HTTP
+                hosts:
+                  - host: "traceability-stable-a-23-12.stable.demo.catena-x.net"
+                    paths:
+                      - path: /
+                        pathType: ImplementationSpecific
+                tls:
+                  - hosts:
+                      - "traceability-stable-a-23-12.stable.demo.catena-x.net"
+                    secretName: tls-secret
+
+              traceability:
+                bpn: "BPNL00000003CML1"
+                url: "https://traceability-stable-a-23-12.stable.demo.catena-x.net"
+              datasource:
+                url: jdbc:postgresql://tx-backend-postgresql-stable-a:5432/trace
+                username: trace
+                password: '<path:traceability-foss/data/stable-a/database#tracePassword>'
+              oauth2:
+                clientId: '<path:traceability-foss/data/stable-a/keycloak/oauth2#clientId>'
+                clientSecret: '<path:traceability-foss/data/stable-a/keycloak/oauth2#clientSecret>'
+                clientTokenUri: "https://centralidp-23-12.stable.demo.catena-x.net/auth/realms/CX-Central/protocol/openid-connect/token"
+                jwkSetUri: "https://centralidp-23-12.stable.demo.catena-x.net/auth/realms/CX-Central/protocol/openid-connect/certs"
+                resourceClient: "app10"
+              edc:
+                apiKey: "<path:traceability-foss/data/stable-a/edc/controlplane#edc.api.control.auth.apikey.value>"
+                providerUrl: "https://tx-edc-consumer-stable-a-controlplane-23-12.stable.demo.catena-x.net"
+                callbackUrl: "http://tx-irs-stable-a:8181/internal/endpoint-data-reference"
+                callbackUrlEdcClient: "https://traceability-stable-a-23-12.stable.demo.catena-x.net/api/internal/endpoint-data-reference"
+                dataEndpointUrl: "https://tx-edc-consumer-stable-a-controlplane-23-12.stable.demo.catena-x.net/management"
+              discoveryfinder:
+                baseUrl: "https://semantics-23-12.stable.demo.catena-x.net/discoveryfinder/api/administration/connectors/discovery/search"
+              config:
+                allowedCorsOriginFirst: "http://localhost:4200/"
+                allowedCorsOriginSecond: "https://traceability-portal-stable-a-23-12.stable.demo.catena-x.net/"
+              irs:
+                baseUrl: "https://tx-irs-stable-a-23-12.stable.demo.catena-x.net"
+              registry:
+                urlWithPath: "https://trace-x-registry-stable-a-23-12.stable.demo.catena-x.net/semantics/registry/api/v3.0"
+              portal:
+                baseUrl: "https://portal-backend-23-12.stable.demo.catena-x.net/api"
+              dependencies:
+                enabled: true
+                irs: "tx-irs-stable-a"
+                edc: "tx-edc-consumer-stable-a"
+            pgadmin4:
+              nameOverride: "tx-pgadmin-stable-a"
+              fullnameOverride: "tx-pgadmin-stable-a"
+              enabled: true
+              strategy:
+                type: Recreate
+              networkPolicy:
+                enabled: false
+              ingress:
+                enabled: true
+                annotations:
+                  kubernetes.io/ingress.class: nginx
+                  nginx.ingress.kubernetes.io/backend-protocol: HTTP
+                hosts:
+                  - host: tx-pgadmin-stable-a-23-12.stable.demo.catena-x.net
+                    paths:
+                      - path: /
+                        pathType: Prefix
+                tls:
+                  - hosts:
+                      - tx-pgadmin-stable-a-23-12.stable.demo.catena-x.net
+                    secretName: tls-secret
+              env:
+                email: pgadmin4@trace.foss
+                password: "<path:traceability-foss/data/stable-a/database#pgadminPassword>"
+                variables:
+                  - name: PGADMIN_CONFIG_UPGRADE_CHECK_ENABLED
+                    value: "False"
+              resources:
+                limits:
+                  cpu: 200m
+                  memory: 512Gi
+                requests:
+                  cpu: 100m
+                  memory: 512Mi
+            postgresql:
+              enabled: true
+              nameOverride: "tx-backend-postgresql-stable-a"
+              fullnameOverride: "tx-backend-postgresql-stable-a"
+              auth:
+                postgresPassword: "<path:traceability-foss/data/stable-a/database#postgresPassword>"
+                password: "<path:traceability-foss/data/stable-a/database#tracePassword>"
+                database: "trace"
+                username: "trace"
+            irs-helm:
+              enabled: true
+              bpn: BPNL00000003CML1
+              nameOverride: "tx-irs-stable-a"
+              fullnameOverride: "tx-irs-stable-a"
+              namespace: product-traceability-foss
+              springprofile: dev
+              irsUrl: "https://tx-irs-stable-a-23-12.stable.demo.catena-x.net"
+              ingress:
+                enabled: true
+                hosts:
+                  - host: "tx-irs-stable-a-23-12.stable.demo.catena-x.net"
+                    paths:
+                      - path: /
+                        pathType: ImplementationSpecific
+                tls:
+                  - hosts:
+                      - "tx-irs-stable-a-23-12.stable.demo.catena-x.net"
+                    secretName: tls-secret
+              digitalTwinRegistry:
+                type: decentral
+                descriptorEndpoint: https://trace-x-registry-stable-a-23-12.stable.demo.catena-x.net/semantics/registry/api/v3.0/shell-descriptors/{aasIdentifier}
+                shellLookupEndpoint: https://trace-x-registry-stable-a-23-12.stable.demo.catena-x.net/semantics/registry/api/v3.0/lookup/shells?assetIds={assetIds}
+                discoveryFinderUrl: https://semantics-23-12.stable.demo.catena-x.net/discoveryfinder/api/administration/connectors/discovery/search
+              semanticshub:
+                url: https://semantics-23-12.stable.demo.catena-x.net/hub/api/v1/models
+              bpdm:
+                url: https://partners-pool-23-12.stable.demo.catena-x.net
+              minioUser: '<path:traceability-foss/data/stable-a/minio#user>'
+              minioPassword: '<path:traceability-foss/data/stable-a/minio#password>'
+              minioUrl: http://tx-irs-minio-stable-a:9000
+              keycloak:
+                oauth2:
+                  clientId: '<path:traceability-foss/data/stable-a/keycloak/oauth2#clientId>'
+                  clientSecret: '<path:traceability-foss/data/stable-a/keycloak/oauth2#clientSecret>'
+                  clientTokenUri: https://centralidp-23-12.stable.demo.catena-x.net/auth/realms/CX-Central/protocol/openid-connect/token
+                  jwkSetUri: https://centralidp-23-12.stable.demo.catena-x.net/auth/realms/CX-Central/protocol/openid-connect/certs
+              edc:
+                callbackurl: http://tx-irs-stable-a:8181/internal/endpoint-data-reference
+                catalog:
+                  cache:
+                    enabled: "false"
+                controlplane:
+                  endpoint:
+                    statesuffix: /state
+                    data: https://tx-edc-consumer-stable-a-controlplane-23-12.stable.demo.catena-x.net/management
+                  apikey:
+                    secret: '<path:traceability-foss/data/stable-a/edc/controlplane#edc.api.control.auth.apikey.value>'
+              minio:
+                nameOverride: "tx-irs-minio-stable-a"
+                fullnameOverride: "tx-irs-minio-stable-a"
+                serviceAccount:
+                  create: false
+                rootUser: '<path:traceability-foss/data/stable-a/minio#user>'
+                rootPassword: '<path:traceability-foss/data/stable-a/minio#password>'
+            tractusx-connector:
+              nameOverride: "tx-edc-consumer-stable-a"
+              fullnameOverride: "tx-edc-consumer-stable-a"
+              enabled: true
+              install:
+                postgresql: false
+                vault: false
+              participant:
+                id: BPNL00000003CML1
+              controlplane:
+                ingresses:
+                  - enabled: true
+                    hostname: "tx-edc-consumer-stable-a-controlplane-23-12.stable.demo.catena-x.net"
+                    annotations:
+                      nginx.ingress.kubernetes.io/ssl-passthrough: "false"
+                      nginx.ingress.kubernetes.io/backend-protocol: "HTTP"
+                      nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
+                    endpoints:
+                      - protocol
+                      - management
+                    tls:
+                      enabled: true
+                      secretName: tls-secret
+                ssi:
+                  miw:
+                    url: '<path:traceability-foss/data/stable-a/edc/wallet#ssi.miw.url>'
+                    authorityId: '<path:traceability-foss/data/stable-a/edc/wallet#ssi.miw.authorityId>'
+                  oauth:
+                    tokenurl: '<path:traceability-foss/data/stable-a/edc/wallet#ssi.oauth.tokenurl>'
+                    client:
+                      id: '<path:traceability-foss/data/stable-a/edc/wallet#ssi.oauth.client.id>'
+                      secretAlias: edc-miw-keycloak-secret-stable-a
+                endpoints:
+                  default:
+                    port: 8080
+                    path: /api
+                  management:
+                    port: 8081
+                    path: /management
+                    authKey: '<path:traceability-foss/data/stable-a/edc/controlplane#edc.api.control.auth.apikey.value>'
+                  control:
+                    port: 8083
+                    path: /control
+                  protocol:
+                    port: 8084
+                    path: /api/v1/dsp
+                  metrics:
+                    port: 9090
+                    path: /metrics
+                  observability:
+                    port: 8085
+                    path: /observability
+                    insecure: true
+                internationalDataSpaces:
+                  id: TXDC
+                  description: Tractus-X Eclipse IDS Data Space Connector
+                  title: ""
+                  maintainer: ""
+                  curator: ""
+                  catalogId: TXDC-Catalog
+                url:
+                  ids: ""
+                resources:
+                  limits:
+                    cpu: 400m
+                    memory: 1.5Gi
+                  requests:
+                    cpu: 200m
+                    memory: 1.5Gi
+              dataplane:
+                ingresses:
+                  - enabled: true
+                    hostname: "tx-edc-consumer-stable-a-dataplane-23-12.stable.demo.catena-x.net"
+                    annotations:
+                      nginx.ingress.kubernetes.io/ssl-passthrough: "false"
+                      nginx.ingress.kubernetes.io/backend-protocol: "HTTP"
+                      nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
+                    endpoints:
+                      - public
+                    className: "nginx"
+                    tls:
+                      enabled: true
+                      secretName: tls-secret
+                endpoints:
+                  default:
+                    port: 8080
+                    path: /api
+                  public:
+                    port: 8081
+                    path: /api/public
+                  control:
+                    port: 8083
+                    path: /api/dataplane/control
+                  observability:
+                    port: 8085
+                    path: /observability
+                    insecure: true
+                  metrics:
+                    port: 9090
+                    path: /metrics
+                url:
+                  public: ""
+                resources:
+                  limits:
+                    cpu: 200m
+                    memory: 512Mi
+                  requests:
+                    cpu: 100m
+                    memory: 512Mi
+              backendService:
+                httpProxyTokenReceiverUrl: "https://traceability-stable-a-23-12.stable.demo.catena-x.net/api/callback/endpoint-data-reference"
+              securityContext:
+                readOnlyRootFilesystem: false
+              vault:
+                hashicorp:
+                  url: "https://vault.demo.catena-x.net"
+                  token: "<path:traceability-foss/data/stable-a/edc#edc.vault.hashicorp.token>"
+                  timeout: 30
+                  healthCheck:
+                    enabled: true
+                    standbyOk: true
+                  paths:
+                    secret: /v1/traceability-foss
+                    health: /v1/sys/health
+                secretNames:
+                  transferProxyTokenSignerPrivateKey: daps-cert-key-stable-a
+                  transferProxyTokenSignerPublicKey: daps-cert-stable-a
+                  transferProxyTokenEncryptionAesKey: token-signer-aes-key
+              postgresql:
+                enabled: true
+                size: 1Gi
+                auth:
+                  username: "<path:traceability-foss/data/stable-a/edc/database#user>"
+                  password: "<path:traceability-foss/data/stable-a/edc/database#password>"
+                username: "<path:traceability-foss/data/stable-a/edc/database#user>"
+                password: "<path:traceability-foss/data/stable-a/edc/database#password>"
+                jdbcUrl: "jdbc:postgresql://tx-edc-consumer-postgresql-stable-a-hl:5432/edc"
+            edc-postgresql:
+              primary:
+                resources:
+                  limits:
+                    cpu: 200m
+                    memory: 1Gi
+                  requests:
+                    cpu: 100m
+                    memory: 1Gi
+              nameOverride: "tx-edc-consumer-postgresql-stable-a"
+              fullnameOverride: "tx-edc-consumer-postgresql-stable-a"
+              enabled: true
+              auth:
+                database: edc
+                username: '<path:traceability-foss/data/stable-a/edc/database#user>'
+                postgresPassword: '<path:traceability-foss/data/stable-a/edc/database#password>'
+                password: '<path:traceability-foss/data/stable-a/edc/database#password>'

--- a/stable/23.12/tx-stable-b.yaml
+++ b/stable/23.12/tx-stable-b.yaml
@@ -1,0 +1,375 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: tx-stable-b
+  namespace: argocd
+spec:
+  project: project-traceability-foss
+  destination:
+    server: 'https://kubernetes.default.svc'
+    namespace: product-traceability-foss
+  source:
+    repoURL: 'https://eclipse-tractusx.github.io/charts/dev'
+    targetRevision: 1.3.18
+    chart: traceability-foss
+    plugin:
+      env:
+        - name: HELM_VALUES
+          value: |
+            global:
+              enablePrometheus: false
+              enableGrafana: false
+            frontend:
+              image:
+                repository: ghcr.io/catenax-ng/tx-traceability-foss
+                tag: 6.0.1-rc4
+                CATENAX_PORTAL_API_URL: '<path:traceability-foss/data/stable-b/frontend#catenax_portal_api_url>'
+                CATENAX_PORTAL_KEYCLOAK_URL: '<path:traceability-foss/data/stable-b/frontend#catenax_portal_keycloak_url>'
+                CATENAX_PORTAL_BACKEND_DOMAIN: '<path:traceability-foss/data/stable-b/frontend#catenax_portal_backend_domain>'
+                CATENAX_PORTAL_URL: '<path:traceability-foss/data/stable-b/frontend#catenax_portal_url>'
+                CATENAX_PORTAL_CLIENT_ID: '<path:traceability-foss/data/stable-b/frontend#catenax_portal_client_id>'
+              nameOverride: "tx-frontend-stable-b"
+              fullnameOverride: "tx-frontend-stable-b"
+              ingress:
+                enabled: true
+                className: "nginx"
+                annotations:
+                  cert-manager.io/cluster-issuer: letsencrypt-prod
+                hosts:
+                  - host: "traceability-portal-stable-b-23-12.stable.demo.catena-x.net"
+                    paths:
+                      - path: /
+                        pathType: ImplementationSpecific
+                tls:
+                  - hosts:
+                      - "traceability-portal-stable-b-23-12.stable.demo.catena-x.net"
+                    secretName: "traceability-portal-stable-b-23-12.stable.demo.catena-x.net-tls"
+            backend:
+              image:
+                repository: ghcr.io/catenax-ng/tx-traceability-foss
+                tag: 6.0.1-rc4
+              nameOverride: "tx-backend-stable-b"
+              fullnameOverride: "tx-backend-stable-b"
+              podSecurityContext:
+                runAsUser: 10001
+                seccompProfile:
+                  type: RuntimeDefault
+              securityContext:
+                allowPrivilegeEscalation: false
+                runAsNonRoot: true
+                runAsUser: 10001
+                runAsGroup: 3000
+                capabilities:
+                  drop:
+                    - ALL
+                readOnlyRootFilesystem: false
+              resources:
+                limits:
+                  cpu: 500m
+                  memory: 512Mi
+                requests:
+                  cpu: 100m
+                  memory: 512Mi
+              springprofile: dev
+              ingress:
+                enabled: true
+                className: "nginx"
+                annotations:
+                  nginx.ingress.kubernetes.io/backend-protocol: HTTP
+                hosts:
+                  - host: "traceability-stable-b-23-12.stable.demo.catena-x.net"
+                    paths:
+                      - path: /
+                        pathType: ImplementationSpecific
+                tls:
+                  - hosts:
+                      - "traceability-stable-b-23-12.stable.demo.catena-x.net"
+                    secretName: tls-secret
+
+              traceability:
+                bpn: "BPNL00000003CNKC"
+                url: "https://traceability-stable-b-23-12.stable.demo.catena-x.net"
+              datasource:
+                url: jdbc:postgresql://tx-backend-postgresql-stable-b:5432/trace
+                username: trace
+                password: '<path:traceability-foss/data/stable-b/database#tracePassword>'
+              oauth2:
+                clientId: '<path:traceability-foss/data/stable-b/keycloak/oauth2#clientId>'
+                clientSecret: '<path:traceability-foss/data/stable-b/keycloak/oauth2#clientSecret>'
+                clientTokenUri: "https://centralidp-23-12.stable.demo.catena-x.net/auth/realms/CX-Central/protocol/openid-connect/token"
+                jwkSetUri: "https://centralidp-23-12.stable.demo.catena-x.net/auth/realms/CX-Central/protocol/openid-connect/certs"
+                resourceClient: "app8"
+              edc:
+                apiKey: "<path:traceability-foss/data/stable-b/edc/controlplane#edc.api.control.auth.apikey.value>"
+                providerUrl: "https://tx-edc-consumer-stable-b-controlplane-23-12.stable.demo.catena-x.net"
+                callbackUrl: "http://tx-irs-stable-b:8181/internal/endpoint-data-reference"
+                callbackUrlEdcClient: "https://traceability-stable-b-23-12.stable.demo.catena-x.net/api/internal/endpoint-data-reference"
+                dataEndpointUrl: "https://tx-edc-consumer-stable-b-controlplane-23-12.stable.demo.catena-x.net/management"
+              discoveryfinder:
+                baseUrl: "https://semantics-23-12.stable.demo.catena-x.net/discoveryfinder/api/administration/connectors/discovery/search"
+              config:
+                allowedCorsOriginFirst: "http://localhost:4200/"
+                allowedCorsOriginSecond: "https://traceability-portal-stable-b-23-12.stable.demo.catena-x.net/"
+              irs:
+                baseUrl: "https://tx-irs-stable-b-23-12.stable.demo.catena-x.net"
+              registry:
+                urlWithPath: "https://trace-x-registry-stable-b-23-12.stable.demo.catena-x.net/semantics/registry/api/v3.0"
+              portal:
+                baseUrl: "https://portal-backend-23-12.stable.demo.catena-x.net/api"
+              dependencies:
+                enabled: true
+                irs: "tx-irs-stable-b"
+                edc: "tx-edc-consumer-stable-b"
+            pgadmin4:
+              nameOverride: "tx-pgadmin-stable-b"
+              fullnameOverride: "tx-pgadmin-stable-b"
+              enabled: true
+              strategy:
+                type: Recreate
+              networkPolicy:
+                enabled: false
+              ingress:
+                enabled: true
+                annotations:
+                  kubernetes.io/ingress.class: nginx
+                  nginx.ingress.kubernetes.io/backend-protocol: HTTP
+                hosts:
+                  - host: tx-pgadmin-stable-b-23-12.stable.demo.catena-x.net
+                    paths:
+                      - path: /
+                        pathType: Prefix
+                tls:
+                  - hosts:
+                      - tx-pgadmin-stable-b-23-12.stable.demo.catena-x.net
+                    secretName: tls-secret
+              env:
+                email: pgadmin4@trace.foss
+                password: "<path:traceability-foss/data/stable-b/database#pgadminPassword>"
+                variables:
+                  - name: PGADMIN_CONFIG_UPGRADE_CHECK_ENABLED
+                    value: "False"
+              resources:
+                limits:
+                  cpu: 200m
+                  memory: 512Gi
+                requests:
+                  cpu: 100m
+                  memory: 512Mi
+            postgresql:
+              enabled: true
+              nameOverride: "tx-backend-postgresql-stable-b"
+              fullnameOverride: "tx-backend-postgresql-stable-b"
+              auth:
+                postgresPassword: "<path:traceability-foss/data/stable-b/database#postgresPassword>"
+                password: "<path:traceability-foss/data/stable-b/database#tracePassword>"
+                database: "trace"
+                username: "trace"
+            irs-helm:
+              enabled: true
+              bpn: BPNL00000003CNKC
+              nameOverride: "tx-irs-stable-b"
+              fullnameOverride: "tx-irs-stable-b"
+              namespace: product-traceability-foss
+              springprofile: dev
+              irsUrl: "https://tx-irs-stable-b-23-12.stable.demo.catena-x.net"
+              ingress:
+                enabled: true
+                hosts:
+                  - host: "tx-irs-stable-b-23-12.stable.demo.catena-x.net"
+                    paths:
+                      - path: /
+                        pathType: ImplementationSpecific
+                tls:
+                  - hosts:
+                      - "tx-irs-stable-b-23-12.stable.demo.catena-x.net"
+                    secretName: tls-secret
+              digitalTwinRegistry:
+                type: decentral
+                descriptorEndpoint: https://trace-x-registry-stable-b-23-12.stable.demo.catena-x.net/semantics/registry/api/v3.0/shell-descriptors/{aasIdentifier}
+                shellLookupEndpoint: https://trace-x-registry-stable-b-23-12.stable.demo.catena-x.net/semantics/registry/api/v3.0/lookup/shells?assetIds={assetIds}
+                discoveryFinderUrl: https://semantics-23-12.stable.demo.catena-x.net/discoveryfinder/api/administration/connectors/discovery/search
+              semanticshub:
+                url: https://semantics-23-12.stable.demo.catena-x.net/hub/api/v1/models
+              bpdm:
+                url: https://partners-pool-23-12.stable.demo.catena-x.net
+              minioUser: '<path:traceability-foss/data/stable-b/minio#user>'
+              minioPassword: '<path:traceability-foss/data/stable-b/minio#password>'
+              minioUrl: http://tx-irs-minio-stable-b:9000
+              keycloak:
+                oauth2:
+                  clientId: '<path:traceability-foss/data/stable-b/keycloak/oauth2#clientId>'
+                  clientSecret: '<path:traceability-foss/data/stable-b/keycloak/oauth2#clientSecret>'
+                  clientTokenUri: https://centralidp-23-12.stable.demo.catena-x.net/auth/realms/CX-Central/protocol/openid-connect/token
+                  jwkSetUri: https://centralidp-23-12.stable.demo.catena-x.net/auth/realms/CX-Central/protocol/openid-connect/certs
+              edc:
+                callbackurl: http://tx-irs-stable-b:8181/internal/endpoint-data-reference
+                catalog:
+                  cache:
+                    enabled: "false"
+                controlplane:
+                  endpoint:
+                    statesuffix: /state
+                    data: https://tx-edc-consumer-stable-b-controlplane-23-12.stable.demo.catena-x.net/management
+                  apikey:
+                    secret: '<path:traceability-foss/data/stable-b/edc/controlplane#edc.api.control.auth.apikey.value>'
+              minio:
+                nameOverride: "tx-irs-minio-stable-b"
+                fullnameOverride: "tx-irs-minio-stable-b"
+                serviceAccount:
+                  create: false
+                rootUser: '<path:traceability-foss/data/stable-b/minio#user>'
+                rootPassword: '<path:traceability-foss/data/stable-b/minio#password>'
+            tractusx-connector:
+              nameOverride: "tx-edc-consumer-stable-b"
+              fullnameOverride: "tx-edc-consumer-stable-b"
+              enabled: true
+              install:
+                postgresql: false
+                vault: false
+              participant:
+                id: BPNL00000003CNKC
+              controlplane:
+                ingresses:
+                  - enabled: true
+                    hostname: "tx-edc-consumer-stable-b-controlplane-23-12.stable.demo.catena-x.net"
+                    annotations:
+                      nginx.ingress.kubernetes.io/ssl-passthrough: "false"
+                      nginx.ingress.kubernetes.io/backend-protocol: "HTTP"
+                      nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
+                    endpoints:
+                      - protocol
+                      - management
+                    tls:
+                      enabled: true
+                      secretName: tls-secret
+                ssi:
+                  miw:
+                    url: '<path:traceability-foss/data/stable-b/edc/wallet#ssi.miw.url>'
+                    authorityId: '<path:traceability-foss/data/stable-b/edc/wallet#ssi.miw.authorityId>'
+                  oauth:
+                    tokenurl: '<path:traceability-foss/data/stable-b/edc/wallet#ssi.oauth.tokenurl>'
+                    client:
+                      id: '<path:traceability-foss/data/stable-b/edc/wallet#ssi.oauth.client.id>'
+                      secretAlias: edc-miw-keycloak-secret-stable-b
+                endpoints:
+                  default:
+                    port: 8080
+                    path: /api
+                  management:
+                    port: 8081
+                    path: /management
+                    authKey: '<path:traceability-foss/data/stable-b/edc/controlplane#edc.api.control.auth.apikey.value>'
+                  control:
+                    port: 8083
+                    path: /control
+                  protocol:
+                    port: 8084
+                    path: /api/v1/dsp
+                  metrics:
+                    port: 9090
+                    path: /metrics
+                  observability:
+                    port: 8085
+                    path: /observability
+                    insecure: true
+                internationalDataSpaces:
+                  id: TXDC
+                  description: Tractus-X Eclipse IDS Data Space Connector
+                  title: ""
+                  maintainer: ""
+                  curator: ""
+                  catalogId: TXDC-Catalog
+                url:
+                  ids: ""
+                resources:
+                  limits:
+                    cpu: 400m
+                    memory: 1.5Gi
+                  requests:
+                    cpu: 200m
+                    memory: 1.5Gi
+              dataplane:
+                ingresses:
+                  - enabled: true
+                    hostname: "tx-edc-consumer-stable-b-dataplane-23-12.stable.demo.catena-x.net"
+                    annotations:
+                      nginx.ingress.kubernetes.io/ssl-passthrough: "false"
+                      nginx.ingress.kubernetes.io/backend-protocol: "HTTP"
+                      nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
+                    endpoints:
+                      - public
+                    className: "nginx"
+                    tls:
+                      enabled: true
+                      secretName: tls-secret
+                endpoints:
+                  default:
+                    port: 8080
+                    path: /api
+                  public:
+                    port: 8081
+                    path: /api/public
+                  control:
+                    port: 8083
+                    path: /api/dataplane/control
+                  observability:
+                    port: 8085
+                    path: /observability
+                    insecure: true
+                  metrics:
+                    port: 9090
+                    path: /metrics
+                url:
+                  public: ""
+                resources:
+                  limits:
+                    cpu: 200m
+                    memory: 512Mi
+                  requests:
+                    cpu: 100m
+                    memory: 512Mi
+              backendService:
+                httpProxyTokenReceiverUrl: "https://traceability-stable-b-23-12.stable.demo.catena-x.net/api/callback/endpoint-data-reference"
+              securityContext:
+                readOnlyRootFilesystem: false
+              vault:
+                hashicorp:
+                  url: "https://vault.demo.catena-x.net"
+                  token: "<path:traceability-foss/data/stable-b/edc#edc.vault.hashicorp.token>"
+                  timeout: 30
+                  healthCheck:
+                    enabled: true
+                    standbyOk: true
+                  paths:
+                    secret: /v1/traceability-foss
+                    health: /v1/sys/health
+                secretNames:
+                  transferProxyTokenSignerPrivateKey: daps-cert-key-stable-b
+                  transferProxyTokenSignerPublicKey: daps-cert-stable-b
+                  transferProxyTokenEncryptionAesKey: token-signer-aes-key
+              postgresql:
+                enabled: true
+                size: 1Gi
+                auth:
+                  username: "<path:traceability-foss/data/stable-b/edc/database#user>"
+                  password: "<path:traceability-foss/data/stable-b/edc/database#password>"
+                username: "<path:traceability-foss/data/stable-b/edc/database#user>"
+                password: "<path:traceability-foss/data/stable-b/edc/database#password>"
+                jdbcUrl: "jdbc:postgresql://tx-edc-consumer-postgresql-stable-b-hl:5432/edc"
+            edc-postgresql:
+              primary:
+                resources:
+                  limits:
+                    cpu: 200m
+                    memory: 1Gi
+                  requests:
+                    cpu: 100m
+                    memory: 1Gi
+              nameOverride: "tx-edc-consumer-postgresql-stable-b"
+              fullnameOverride: "tx-edc-consumer-postgresql-stable-b"
+              enabled: true
+              auth:
+                database: edc
+                username: '<path:traceability-foss/data/stable-b/edc/database#user>'
+                postgresPassword: '<path:traceability-foss/data/stable-b/edc/database#password>'
+                password: '<path:traceability-foss/data/stable-b/edc/database#password>'

--- a/stable/3.2/agent-consumer-connector.yaml
+++ b/stable/3.2/agent-consumer-connector.yaml
@@ -1,0 +1,115 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: agent-consumer-connector
+  namespace: argocd
+spec:
+  destination:
+    namespace: product-knowledge
+    server: https://kubernetes.default.svc
+  project: project-knowledge
+  source:
+    repoURL: https://eclipse-tractusx.github.io/charts/dev
+    targetRevision: 1.9.8
+    chart: agent-connector-memory
+    plugin:
+      env:
+        - name: HELM_VALUES
+          value: |
+            participant:
+              id: BPNL0000000005VV
+            nameOverride: agent-connector-consumer
+            fullnameOverride: agent-connector-consumer
+            vault:
+              hashicorp:
+                enabled: true
+                url: https://vault.demo.catena-x.net
+                token: s.XRMTpxjFiEmCN6iPg4itBdXv
+                healthCheck:
+                  enabled: false
+                  standbyOk: true
+                paths:
+                  secret: /v1/knowledge
+              secretNames:
+                transferProxyTokenSignerPrivateKey: consumer-key
+                transferProxyTokenSignerPublicKey: consumer-cert
+                transferProxyTokenEncryptionAesKey: consumer-symmetric-key
+            controlplane:
+              securityContext:
+                readOnlyRootFilesystem: false
+              image:
+                pullPolicy: Always
+              ssi:
+                miw:
+                  # -- MIW URL
+                  url: "https://managed-identity-wallets-new.stable.demo.catena-x.net"
+                  # -- The BPN of the issuer authority
+                  authorityId: "BPNL00000003CRHK"
+                oauth:
+                  # -- The URL (of KeyCloak), where access tokens can be obtained
+                  tokenurl: "https://centralidp.stable.demo.catena-x.net/auth/realms/CX-Central/protocol/openid-connect/token"
+                  client:
+                    # -- The client ID for KeyCloak
+                    id: "sa5"
+                    # -- The alias under which the client secret is stored in the vault.
+                    secretAlias: "stable-consumer-miw"
+              endpoints:
+                management:
+                  authKey: "dwt6stvctwewv3vtf624"
+              ## Ingress declaration to expose the network service.
+              ingresses:
+                - enabled: true
+                  # -- The hostname to be used to precisely map incoming traffic onto the underlying network service
+                  hostname: "agent-consumer-cp.stable.demo.catena-x.net"
+                  # -- EDC endpoints exposed by this ingress resource
+                  endpoints:
+                    - protocol
+                    - management
+                    - control
+                  # -- Enables TLS on the ingress resource
+                  tls:
+                    enabled: true
+            dataplanes:
+              dataplane:
+                securityContext:
+                  readOnlyRootFilesystem: false
+                image:
+                  pullPolicy: Always
+                configs:
+                  dataspace.ttl: |-
+                    ################################################
+                    # Catena-X BT Agent Bootstrap
+                    ################################################
+                    @prefix : <GraphAsset?local=Dataspace> .
+                    @prefix cx: <https://raw.githubusercontent.com/catenax-ng/product-knowledge/main/ontology/cx_ontology.ttl#> .
+                    @prefix cx-common: <https://w3id.org/catenax/ontology/common#> .
+                    @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+                    @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+                    @prefix bpnl: <bpn:legal:> .
+                    @base <GraphAsset?local=Dataspace> .
+
+                    bpnl:BPNL000000000001 cx:hasBusinessPartnerNumber "BPNL000000000001"^^xsd:string;
+                                          cx:hasConnector <edcs://agent-provider-cp.stable.demo.catena-x.net>;
+                                          cx-common:hasConnector <edcs://agent-provider-cp.stable.demo.catena-x.net>.
+
+                    bpnl:BPNL0000000005VV cx:hasBusinessPartnerNumber "BPNL0000000005VV"^^xsd:string;
+                                          cx:hasConnector <edcs://agent-consumer-cp.stable.demo.catena-x.net>;
+                                          cx-common:hasConnector <edcs://agent-consumer-cp.stable.demo.catena-x.net>.
+                agent:
+                  # synchronization: 360000
+                  connectors:
+                    - https://agent-provider-cp.stable.demo.catena-x.net
+
+                ## Ingress declaration to expose the network service.
+                ingresses:
+                  - enabled: true
+                    hostname: "agent-consumer-dp.stable.demo.catena-x.net"
+                    # -- EDC endpoints exposed by this ingress resource
+                    endpoints:
+                      - public
+                      - default
+                      - control
+                      - callback
+                    # -- Enables TLS on the ingress resource
+                    tls:
+                      enabled: true

--- a/stable/3.2/agent-provider-connector.yaml
+++ b/stable/3.2/agent-provider-connector.yaml
@@ -1,0 +1,115 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: agent-provider-connector
+  namespace: argocd
+spec:
+  destination:
+    namespace: product-knowledge
+    server: https://kubernetes.default.svc
+  project: project-knowledge
+  source:
+    repoURL: 'https://eclipse-tractusx.github.io/charts/dev'
+    targetRevision: 1.9.8
+    chart: agent-connector-memory
+    plugin:
+      env:
+        - name: HELM_VALUES
+          value: |
+            participant:
+              id: BPNL000000000001
+            nameOverride: agent-connector-provider
+            fullnameOverride: agent-connector-provider
+            vault:
+              hashicorp:
+                enabled: true
+                url: https://vault.demo.catena-x.net
+                token: s.XRMTpxjFiEmCN6iPg4itBdXv
+                healthCheck:
+                  enabled: false
+                  standbyOk: true
+                paths:
+                  secret: /v1/knowledge
+              secretNames:
+                transferProxyTokenSignerPrivateKey: oem-key
+                transferProxyTokenSignerPublicKey: oem-cert
+                transferProxyTokenEncryptionAesKey: oem-symmetric-key
+            controlplane:
+              securityContext:
+                readOnlyRootFilesystem: false
+              image:
+                pullPolicy: Always
+              ssi:
+                miw:
+                  # -- MIW URL
+                  url: "https://managed-identity-wallets-new.stable.demo.catena-x.net"
+                  # -- The BPN of the issuer authority
+                  authorityId: "BPNL00000003CRHK"
+                oauth:
+                  # -- The URL (of KeyCloak), where access tokens can be obtained
+                  tokenurl: "https://centralidp.stable.demo.catena-x.net/auth/realms/CX-Central/protocol/openid-connect/token"
+                  client:
+                    # -- The client ID for KeyCloak
+                    id: "sa4"
+                    # -- The alias under which the client secret is stored in the vault.
+                    secretAlias: "stable-provider-miw"
+              endpoints:
+                management:
+                  authKey: "dwt6stvctwewv3vtf624"
+              ## Ingress declaration to expose the network service.
+              ingresses:
+                - enabled: true
+                  # -- The hostname to be used to precisely map incoming traffic onto the underlying network service
+                  hostname: "agent-provider-cp.stable.demo.catena-x.net"
+                  # -- EDC endpoints exposed by this ingress resource
+                  endpoints:
+                    - protocol
+                    - management
+                    - control
+                  # -- Enables TLS on the ingress resource
+                  tls:
+                    enabled: true
+            dataplanes:
+              dataplane:
+                securityContext:
+                  readOnlyRootFilesystem: false
+                image:
+                  pullPolicy: Always
+                configs:
+                  dataspace.ttl: |-
+                    ################################################
+                    # Catena-X BT Agent Bootstrap
+                    ################################################
+                    @prefix : <GraphAsset?local=Dataspace> .
+                    @prefix cx: <https://raw.githubusercontent.com/catenax-ng/product-knowledge/main/ontology/cx_ontology.ttl#> .
+                    @prefix cx-common: <https://w3id.org/catenax/ontology/common#> .
+                    @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+                    @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+                    @prefix bpnl: <bpn:legal:> .
+                    @base <GraphAsset?local=Dataspace> .
+
+                    bpnl:BPNL000000000001 cx:hasBusinessPartnerNumber "BPNL000000000001"^^xsd:string;
+                                          cx:hasConnector <edcs://agent-provider-cp.stable.demo.catena-x.net>;
+                                          cx-common:hasConnector <edcs://agent-provider-cp.stable.demo.catena-x.net>.
+
+                    bpnl:BPNL0000000005VV cx:hasBusinessPartnerNumber "BPNL0000000005VV"^^xsd:string;
+                                          cx:hasConnector <edcs://agent-consumer-cp.stable.demo.catena-x.net>;
+                                          cx-common:hasConnector <edcs://agent-consumer-cp.stable.demo.catena-x.net>.
+                agent:
+                  #synchronization: 360000
+                  connectors:
+                    - https://agent-provider-cp.stable.demo.catena-x.net
+
+                ## Ingress declaration to expose the network service.
+                ingresses:
+                  - enabled: true
+                    hostname: "agent-provider-dp.stable.demo.catena-x.net"
+                    # -- EDC endpoints exposed by this ingress resource
+                    endpoints:
+                      - public
+                      - default
+                      - control
+                      - callback
+                    # -- Enables TLS on the ingress resource
+                    tls:
+                      enabled: true

--- a/stable/3.2/bpdm.yaml
+++ b/stable/3.2/bpdm.yaml
@@ -1,0 +1,264 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: bpdm
+  namespace: argocd
+spec:
+  project: project-bpdm
+  destination:
+    server: 'https://kubernetes.default.svc'
+    namespace: product-bpdm
+  source:
+    repoURL: 'https://eclipse-tractusx.github.io/charts/dev'
+    targetRevision: 3.0.4
+    chart: bpdm
+    plugin:
+      env:
+        - name: HELM_VALUES
+          value: |
+            bpdm-gate:
+              fullnameOverride: bpdm-stable-gate-test-company
+              enabled: true
+              replicaCount: 1
+              resources:
+                limits:
+                  cpu: 800m
+                  memory: 2Gi
+                requests:
+                  cpu: 300m
+                  memory: 2Gi
+              springProfiles:
+                - auth
+              ingress:
+                enabled: true
+                hosts:
+                  - host: business-partners.stable.demo.catena-x.net
+                    paths:
+                      - path: "/companies/test-company"
+                        pathType: Prefix
+                tls:
+                  - secretName: tls-secret
+                    hosts:
+                      - business-partners.stable.demo.catena-x.net
+              livenessProbe:
+                httpGet:
+                  path: "/companies/test-company/actuator/health/liveness"
+              readinessProbe:
+                httpGet:
+                  path: "/companies/test-company/actuator/health/readiness"
+              startupProbe:
+                httpGet:
+                  path: "/companies/test-company/actuator/health/readiness"
+              applicationConfig:
+                server:
+                  servlet:
+                    context-path: "/companies/test-company"
+                bpdm:
+                  gate-security:
+                    changeCompanyInputData: update_company_data
+                    changeCompanyOutputData: update_company_data
+                    readCompanyInputData: view_company_data
+                    readCompanyOutputData: view_shared_data
+                  security:
+                    auth-server-url: https://centralidp.stable.demo.catena-x.net/auth
+                    realm: CX-Central
+                    client-id: Cl16-CX-BPDMGate
+                springdoc:
+                  swagger-ui:
+                    oauth:
+                      client-id: Cl2-CX-Portal
+              applicationSecrets:
+                spring:
+                  datasource:
+                    password: '<path:bpdm/data/stable/pool/postgresql#password>'
+              postgres:
+                enabled: false
+            bpdm-pool:
+              fullnameOverride: bpdm-stable-pool
+              enabled: true
+              springProfiles:
+                - auth
+              resources:
+                limits:
+                  cpu: 800m
+                  memory: 2Gi
+                requests:
+                  cpu: 300m
+                  memory: 2Gi
+              ingress:
+                enabled: true
+                annotations:
+                  kubernetes.io/ingress.class: nginx
+                  nginx.ingress.kubernetes.io/backend-protocol: "HTTP"
+                hosts:
+                  - host: business-partners.stable.demo.catena-x.net
+                    paths:
+                      - path: /pool
+                        pathType: Prefix
+                tls:
+                  - secretName: tls-secret
+                    hosts:
+                      - business-partners.stable.demo.catena-x.net
+              livenessProbe:
+                httpGet:
+                  path: "/pool/actuator/health/liveness"
+              readinessProbe:
+                httpGet:
+                  path: "/pool/actuator/health/readiness"
+              startupProbe:
+                httpGet:
+                  path: "/pool/actuator/health/readiness"
+              applicationConfig:
+                server:
+                  servlet:
+                    context-path: "/pool"
+                bpdm:
+                  pool-security:
+                    readPoolPartnerData: view_company_data
+                    changePoolPartnerData: add_company_data
+                    readMetaData: view_company_data
+                    changeMetaData: add_company_data
+                    manageOpensearch: add_company_data
+                  opensearch:
+                    # every hour at minute 30
+                    export-scheduler-cron-expr: 0 30 * * * *
+                  security:
+                    auth-server-url: https://centralidp.stable.demo.catena-x.net/auth
+                    realm: CX-Central
+                    client-id: Cl7-CX-BPDM
+                springdoc:
+                  swagger-ui:
+                    oauth:
+                      client-id: Cl2-CX-Portal
+              applicationSecrets:
+                spring:
+                  datasource:
+                    password: '<path:bpdm/data/stable/pool/postgresql#password>'
+              opensearch:
+                fullnameOverride: "bpdm-stable-opensearch"
+
+            bpdm-bridge-dummy:
+              fullnameOverride: bpdm-stable-bridge
+              springProfiles:
+                - auth
+              ingress:
+                enabled: true
+                annotations:
+                  kubernetes.io/ingress.class: nginx
+                  nginx.ingress.kubernetes.io/backend-protocol: "HTTP"
+                hosts:
+                  - host: business-partners.stable.demo.catena-x.net
+                    paths:
+                      - path: /bridge
+                        pathType: Prefix
+                tls:
+                  - secretName: tls-secret
+                    hosts:
+                      - business-partners.stable.demo.catena-x.net
+              livenessProbe:
+                httpGet:
+                  path: "/bridge/actuator/health/liveness"
+              readinessProbe:
+                httpGet:
+                  path: "/bridge/actuator/health/readiness"
+              startupProbe:
+                httpGet:
+                  path: "/bridge/actuator/health/readiness"
+              resources:
+                limits:
+                  cpu: 800m
+                  memory: 2Gi
+                requests:
+                  cpu: 300m
+                  memory: 2Gi
+              applicationConfig:
+                server:
+                  servlet:
+                    context-path: "/bridge"
+                bpdm:
+                  bridge:
+                    syncAuthorities: add_company_data
+                  pool:
+                    base-url: "http://bpdm-stable-pool:8080/pool"
+                  gate:
+                    base-url: "http://bpdm-stable-gate-test-company:8080/companies/test-company"
+                  security:
+                    auth-server-url: https://centralidp.stable.demo.catena-x.net/auth
+                    realm: CX-Central
+                    client-id: Cl7-CX-BPDM
+                spring:
+                  security:
+                    oauth2:
+                      client:
+                        registration:
+                          bridge-client:
+                            # Client ID used for getting token different from own Client to validate tokens
+                            client-id: sa-cl7-cx-7
+                        provider:
+                          catena-keycloak-provider:
+                            issuer-uri: https://centralidp.stable.demo.catena-x.net/auth/realms/CX-Central
+              applicationSecrets:
+                spring:
+                  datasource:
+                    password: '<path:bpdm/data/stable/pool/postgresql#password>'
+                bpdm:
+                  security:
+                    credentials:
+                      secret: '<path:bpdm/data/stable/admin-user#client-secret>'
+
+            opensearch:
+              masterService: ""
+              fullnameOverride: "bpdm-stable-opensearch"
+              enabled: true
+              replicas: 1
+              protocol: http
+              roles:
+                - master
+                - ingest
+                - data
+              resources:
+                limits:
+                  cpu: 300m
+                  memory: 2Gi
+                requests:
+                  cpu: 100m
+                  memory: 2Gi
+              config:
+                opensearch.yml: |
+                  # Bind to all interfaces because we don't know what
+                  # IP address Docker will assign to us.
+                  network.host: 0.0.0.0
+                  # Disable security
+                  plugins.security.disabled: true
+              securityConfig:
+                enabled: false
+              extraInitContainers:
+                # Image that performs the sysctl operation to modify Kernel settings
+                # needed sometimes to avoid boot errors
+                - name: sysctl
+                  image: docker.io/bitnami/bitnami-shell:10-debian-10-r199
+                  imagePullPolicy: "IfNotPresent"
+                  command:
+                    - /bin/bash
+                    - -ec
+                    - |
+                      CURRENT=`sysctl -n vm.max_map_count`;
+                      DESIRED="262144";
+                      if [ "$DESIRED" -gt "$CURRENT" ]; then
+                          sysctl -w vm.max_map_count=262144;
+                      fi;
+                      CURRENT=`sysctl -n fs.file-max`;
+                      DESIRED="65536";
+                      if [ "$DESIRED" -gt "$CURRENT" ]; then
+                          sysctl -w fs.file-max=65536;
+                      fi;
+                  securityContext:
+                    runAsUser: 0
+                    privileged: true
+
+            postgres:
+              auth:
+                postgresPassword: '<path:bpdm/data/stable/pool/postgresql#postgres-password>'
+                password: '<path:bpdm/data/stable/pool/postgresql#password>'
+              chart: bpdm
+

--- a/stable/3.2/bpdm.yaml
+++ b/stable/3.2/bpdm.yaml
@@ -1,7 +1,7 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
-  name: bpdm
+  name: bpdm-stable
   namespace: argocd
 spec:
   project: project-bpdm

--- a/stable/3.2/bpndiscovery-service.yaml
+++ b/stable/3.2/bpndiscovery-service.yaml
@@ -1,0 +1,63 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: bpndiscovery-service
+  namespace: argocd
+spec:
+  project: project-semantics
+  destination:
+    server: 'https://kubernetes.default.svc'
+    namespace: product-semantics
+  source:
+    repoURL: 'https://eclipse-tractusx.github.io/charts/dev'
+    targetRevision: 0.1.11
+    chart: bpndiscovery
+    plugin:
+      env:
+        - name: HELM_VALUES
+          value: |
+            bpndiscovery:
+              enablePostgres: true
+              image:
+                imagePullPolicy: IfNotPresent
+              replicaCount: 1
+              containerPort: 4243
+              host: semantics.stable.demo.catena-x.net
+              ## If 'authentication' is set to false, no OAuth authentication is enforced
+              authentication: true
+              idp:
+                issuerUri: "https://centralidp.stable.demo.catena-x.net/auth/realms/CX-Central"
+                publicClientId: '<path:semantics/data/authentication#idpClientIdBpnDiscovery>'
+                bpnIdClaimName: bpn
+              ## Needed for the self-registration on discovery-finder
+              bpndiscoveryEndpoint:
+                allowedTypes: oen,wmi,passtype,manufacturerPartId
+                description: Service to discover BPN for different kind of type numbers
+                endpointAddress: https://semantics.stable.demo.catena-x.net/bpndiscovery
+                documentation: https://semantics.stable.demo.catena-x.net/bpndiscovery/swagger-ui/index.html
+              ## Configure discoveryFinderClient to register the bpn-discovery on discovery-finder.Properties needed for spring-security config.
+              discoveryfinderClient:
+                baseUrl: https://semantics.stable.demo.catena-x.net/discoveryfinder
+                registration:
+                  clientId: '<path:semantics/data/authentication#discoveryFinder-technical-user>'
+                  clientSecret: '<path:semantics/data/authentication#discoveryFinder-technical-user-password-stable>'
+                  authorizationGrantType: client_credentials
+                schedulerCronFrequency: "0 0 */1 * * *"
+                provider:
+                  tokenUri: https://centralidp.stable.demo.catena-x.net/auth/realms/CX-Central/protocol/openid-connect/token
+              dataSource:
+                driverClassName: org.postgresql.Driver
+                sqlInitPlatform: pg
+                ## The url, user, and password parameter will be ignored if 'enablePostgres' is set to true.
+                ## In that case the postgresql auth parameters are used.
+                url: jdbc:postgresql://semantic-services-postgresql:5432/bpndiscovery
+                user: catenax
+                password: '<path:semantics/data/authentication#dbpassword>'
+              ingress:
+                enabled: true
+                tls: true
+              postgresql:
+                auth:
+                  username: catenax
+                  password: '<path:semantics/data/authentication#dbpassword>'
+                  database: bpndiscovery

--- a/stable/3.2/centralidp.yaml
+++ b/stable/3.2/centralidp.yaml
@@ -1,0 +1,79 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: centralidp
+  namespace: argocd
+spec:
+  project: project-portal
+  destination:
+    server: 'https://kubernetes.default.svc'
+    namespace: product-portal
+  source:
+    repoURL: 'https://eclipse-tractusx.github.io/charts/dev'
+    targetRevision: 1.2.0
+    chart: centralidp
+    plugin:
+      env:
+        - name: HELM_VALUES
+          value: |
+            keycloak:
+              initContainers:
+                - name: import
+                  image: tractusx/portal-iam-consortia:v1.2.0
+                  imagePullPolicy: Always
+                  command:
+                    - sh
+                  args:
+                    - -c
+                    - |
+                      echo "Copying themes..."
+                      cp -R /import/themes/catenax-central/* /themes
+                      echo "Copying realms..."
+                      cp -R /import/catenax-central/stable/realms/* /realms
+                  volumeMounts:
+                  - name: themes
+                    mountPath: "/themes"
+                  - name: realms
+                    mountPath: "/realms"
+              ingress:
+                enabled: true
+                ingressClassName: nginx
+                hostname: centralidp.stable.demo.catena-x.net
+                annotations:
+                  cert-manager.io/cluster-issuer: letsencrypt-prod
+                  nginx.ingress.kubernetes.io/cors-allow-credentials: "true"
+                  nginx.ingress.kubernetes.io/cors-allow-methods: PUT, GET, POST, OPTIONS
+                  nginx.ingress.kubernetes.io/cors-allow-origin: https://centralidp.stable.demo.catena-x.net, http://localhost:3000
+                  nginx.ingress.kubernetes.io/enable-cors: "true"
+                  nginx.ingress.kubernetes.io/proxy-buffer-size: 128k
+                  nginx.ingress.kubernetes.io/proxy-buffering: "on"
+                  nginx.ingress.kubernetes.io/proxy-buffers-number: "20"
+                  nginx.ingress.kubernetes.io/use-regex: "true"
+                tls: true
+            secrets:
+              auth:
+                existingSecret:
+                  adminpassword: "<path:portal/data/stable/iam/centralidp-keycloak#admin-password>"
+                  managementpassword: "<path:portal/data/stable/iam/centralidp-keycloak#management-password>"
+              postgresql:
+                auth:
+                  existingSecret:
+                    postgrespassword: "<path:portal/data/stable/iam/centralidp-postgres#postgres-password>"
+                    password: "<path:portal/data/stable/iam/centralidp-postgres#password>"
+                    replicationPassword: "<path:portal/data/stable/iam/centralidp-postgres#replication-password>"
+            seeding:
+              enabled: true
+              initContainers:
+                - name: init-cx-central
+                  image: tractusx/portal-iam-consortia:v1.2.0
+                  imagePullPolicy: Always
+                  command:
+                    - sh
+                  args:
+                    - -c
+                    - |
+                      echo "Copying CX Central realm..."
+                      cp -R /import/catenax-central/stable/realms/* /app/realms
+                  volumeMounts:
+                  - name: realms
+                    mountPath: "app/realms"

--- a/stable/3.2/digital-product-pass.yaml
+++ b/stable/3.2/digital-product-pass.yaml
@@ -1,0 +1,193 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: digital-product-pass
+  namespace: argocd
+spec:
+  project: project-material-pass
+  destination:
+    server: 'https://kubernetes.default.svc'
+    namespace: product-material-pass
+  source:
+    repoURL: 'https://eclipse-tractusx.github.io/charts/dev'
+    targetRevision: 1.0.1
+    chart: digital-product-pass
+    helm:
+      valueFiles:
+        - values.yaml
+      parameters:
+        - name: backend.ingress.enabled
+          value: 'true'
+        - name: backend.avp.helm.clientId
+          value: sa2
+        - name: backend.avp.helm.clientSecret
+          value: fdug2SLMjjTBEBCth5zFjgdT9uP27Wyg
+        - name: backend.avp.helm.participantId
+          value: BPNL00000000CBA5
+        - name: backend.avp.helm.xApiKey
+          value: password
+      values: |-
+        frontend:
+          ingress:
+            enabled: true
+            #className: ""
+            annotations:
+              ingressClassName: nginx
+              # kubernetes.io/tls-acme: "true"
+              nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
+              nginx.ingress.kubernetes.io/ssl-passthrough: "false"
+              nginx.ingress.kubernetes.io/rewrite-target: /$2
+              nginx.ingress.kubernetes.io/backend-protocol: "HTTP"
+              nginx.ingress.kubernetes.io/service-upstream: "true"
+            hosts:
+              - host: materialpass.stable.demo.catena-x.net
+                paths:
+                  - path: /passport(/|$)(.*)
+                    pathType: Prefix
+            tls:
+              - secretName: tls-secret
+                hosts:
+                  - materialpass.stable.demo.catena-x.net
+
+          productpass:
+            backend_url: "materialpass.stable.demo.catena-x.net"
+            idp_url: "centralidp.stable.demo.catena-x.net/auth/"
+            keycloak:
+              clientId: "Cl13-CX-Battery"
+              realm: "CX-Central"
+              onLoad: "login-required"
+
+        backend:
+          ingress:
+            enabled: true
+            # className: "nginx"
+            annotations:
+              ingressClassName: nginx
+              # kubernetes.io/tls-acme: "true"
+              nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
+              nginx.ingress.kubernetes.io/ssl-passthrough: "false"
+              nginx.ingress.kubernetes.io/backend-protocol: "HTTP"
+            hosts:
+              - host: materialpass.stable.demo.catena-x.net
+                paths:
+                  - path: /
+                    pathType: Prefix
+            tls:
+              - secretName: tls-secret
+                hosts:
+                  - materialpass.stable.demo.catena-x.net
+
+          avp:
+            helm:
+              clientId: sa2
+              clientSecret: fdug2SLMjjTBEBCth5zFjgdT9uP27Wyg
+              xApiKey: password
+              participantId: BPNL00000000CBA5
+
+          application:
+            yml: |-
+              spring:
+                name: 'Catena-X Product Passport Consumer Backend'
+                main:
+                  allow-bean-definition-overriding: true
+                devtools:
+                  add-properties: false
+                jackson:
+                  serialization:
+                    indent_output: true
+
+              logging:
+                level:
+                  root: INFO
+                  utils: INFO
+
+              configuration:
+                maxRetries: 5
+
+                keycloak:
+                  realm: CX-Central
+                  resource: Cl13-CX-Battery
+                  tokenUri: 'https://centralidp.stable.demo.catena-x.net/auth/realms/CX-Central/protocol/openid-connect/token'
+                  userInfoUri: 'https://centralidp.stable.demo.catena-x.net/auth/realms/CX-Central/protocol/openid-connect/userinfo'
+
+                edc:
+                  endpoint: 'https://materialpass.stable.demo.catena-x.net/consumer'
+                  management: '/management/v2'
+                  catalog: '/catalog/request'
+                  negotiation: '/contractnegotiations'
+                  transfer: '/transferprocesses'
+                  receiverEndpoint: 'https://materialpass.stable.demo.catena-x.net/endpoint'
+                  delay:  100 # -- Negotiation status Delay in milliseconds in between async requests [<= 500]
+
+                security:
+                  check:
+                    enabled: false
+                    bpn: true
+                    edc: true
+
+                dtr:
+                  central: false
+                  centralUrl: 'https://semantics.stable.demo.catena-x.net/registry'
+                  assetId: 'digital-twin-registry'
+                  dspEndpointKey: 'dspEndpoint'
+                  endpointInterface: 'SUBMODEL-3.0'
+                  internalDtr: "https://materialpass.stable.demo.catena-x.net/BPNL000000000000" # -- If there is an internal DTR available it can be referenced here and will be injected in the list of DTRs
+                  decentralApis:
+                    search: "/lookup/shells/query"
+                    digitalTwin: "/shell-descriptors"
+                    subModel: "/submodel-descriptors"
+                  timeouts:
+                    search: 10
+                    negotiation: 40
+                    transfer: 10
+                    digitalTwin: 20
+                  temporaryStorage: true
+
+                discovery:
+                  endpoint: "https://semantics.stable.demo.catena-x.net/discoveryfinder/api/administration/connectors/discovery/search"
+                  bpn:
+                    key: "manufacturerPartId"
+                    searchPath: "/api/administration/connectors/bpnDiscovery/search"
+                  edc:
+                    key: "bpn"
+
+
+                process:
+                  store: true
+                  dir: 'process'
+                  indent: true
+                  signKey: 'ca138db29b3727b1927383184f155bb8cb2e0127ee33bba35fab846e240e98425be5fd68c7656445eced5ea0ea5b3bd2676f0b6f30105b16962da27333176b9e'
+
+                passport:
+                  dataTransfer:
+                    encrypt: true
+                    indent: true
+                    dir: "data/transfer"
+                  versions:
+                    - 'v3.0.1'
+
+                vault:
+                  type: 'local'
+                  file: 'vault.token.yml'
+                  pathSep: "."
+                  prettyPrint: true
+                  indent: 2
+                  defaultValue: '<Add secret value here>'
+                  attributes:
+                    - "client.id"
+                    - "client.secret"
+                    - "edc.apiKey"
+                    - "edc.participantId"
+
+              server:
+                error:
+                  include-message: ALWAYS
+                  include-binding-errors: ALWAYS
+                  include-stacktrace: ON_PARAM
+                  include-exception: false
+                port: 8888
+                tomcat:
+                  max-connections: 10000
+  syncPolicy:
+    syncOptions:
+      - Replace=true

--- a/stable/3.2/discovery-finder.yaml
+++ b/stable/3.2/discovery-finder.yaml
@@ -1,0 +1,55 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: discoveryfinder-service
+  namespace: argocd
+spec:
+  project: project-semantics
+  destination:
+    server: 'https://kubernetes.default.svc'
+    namespace: product-semantics
+  source:
+    repoURL: 'https://eclipse-tractusx.github.io/charts/dev'
+    targetRevision: 0.1.11
+    chart: discoveryfinder
+    plugin:
+      env:
+        - name: HELM_VALUES
+          value: |
+            discoveryfinder:
+              enablePostgres: true
+              image:
+                imagePullPolicy: IfNotPresent
+              replicaCount: 1
+              containerPort: 4243
+              host: semantics.stable.demo.catena-x.net
+              ## If 'authentication' is set to false, no OAuth authentication is enforced
+              authentication: true
+              properties:
+                discoveryfinder:
+                  # Initial Endpoint for edc discovery with type bpn
+                  initialEndpoints:
+                    - type: bpn
+                      endpointAddress: https://portal-backend.stable.demo.catena-x.net/api/administration/Connectors/discovery
+                      description: Service to discover connector endpoints based on bpns
+                      documentation: https://portal-backend.stable.demo.catena-x.net/api/administration/swagger/index.html
+              idp:
+                issuerUri: "https://centralidp.stable.demo.catena-x.net/auth/realms/CX-Central"
+                publicClientId: '<path:semantics/data/authentication#idpClientIdDiscoveryFinder>'
+              dataSource:
+                driverClassName: org.postgresql.Driver
+                sqlInitPlatform: pg
+                ## The url, user, and password parameter will be ignored if 'enablePostgres' is set to true.
+                ## In that case the postgresql auth parameters are used.
+                url: jdbc:postgresql://semantic-services-postgresql:5432/discoveryfinder
+                user: catenax
+                password: '<path:semantics/data/authentication#dbpassword>'
+              ingress:
+                enabled: true
+                tls: true
+              postgresql:
+                auth:
+                  username: catenax
+                  password: '<path:semantics/data/authentication#dbpassword>'
+                  database: discoveryfinder
+

--- a/stable/3.2/dpp-edc-consumer.yaml
+++ b/stable/3.2/dpp-edc-consumer.yaml
@@ -1,0 +1,175 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: dpp-edc-consumer
+  namespace: argocd
+spec:
+  project: project-material-pass
+  destination:
+    server: 'https://kubernetes.default.svc'
+    namespace: product-material-pass
+  source:
+    repoURL: 'https://eclipse-tractusx.github.io/charts/dev'
+    targetRevision: 0.5.0
+    chart: tractusx-connector
+    helm:
+      valueFiles:
+        - values.yaml
+      values: |
+        participant:
+          id: "BPNL00000000CBA5"
+
+        controlplane:
+          enabled: true
+          endpoints:
+            # -- default api for health checks, should not be added to any ingress
+            default:
+              # -- port for incoming api calls
+              port: 8080
+              # -- path for incoming api calls
+              path: /consumer/api
+            # -- data management api, used by internal users, can be added to an ingress and must not be internet facing
+            management:
+              # -- port for incoming api calls
+              port: 8081
+              # -- path for incoming api calls
+              path: /consumer/management
+              # -- authentication key, must be attached to each 'X-Api-Key' request header
+              authKey: password
+            # -- control api, used for internal control calls. can be added to the internal ingress, but should probably not
+            control:
+              # -- port for incoming api calls
+              port: 8083
+              # -- path for incoming api calls
+              path: /consumer/control
+            # -- ids api, used for inter connector communication and must be internet facing
+            protocol:
+              # -- port for incoming api calls
+              port: 8084
+              # -- path for incoming api calls
+              path: /consumer/api/v1/dsp
+            # -- metrics api, used for application metrics, must not be internet facing
+            metrics:
+              # -- port for incoming api calls
+              port: 9090
+              # -- path for incoming api calls
+              path: /consumer/metrics
+            # -- observability api with unsecured access, must not be internet facing
+            observability:
+              # -- port for incoming API calls
+              port: 8085
+              # -- observability api, provides /health /readiness and /liveness endpoints
+              path: /consumer/observability
+              # -- allow or disallow insecure access, i.e. access without authentication
+              insecure: true
+
+          ssi:
+            miw:
+              url: "https://managed-identity-wallets-new.stable.demo.catena-x.net"
+              authorityId: "BPNL00000003CRHK"
+            oauth:
+              tokenurl: "https://centralidp.stable.demo.catena-x.net/auth/realms/CX-Central/protocol/openid-connect/token"
+              client:
+                id: "sa3"
+                secretAlias: "stable-client-secret"
+            endpoint:
+              audience: https://materialpass.stable.demo.catena-x.net/consumer
+
+          ## Ingress declaration to expose the network service.
+          ingresses:
+            ## Public / Internet facing Ingress
+            - enabled: true
+              # -- The hostname to be used to precisely map incoming traffic onto the underlying network service
+              hostname: "materialpass.stable.demo.catena-x.net"
+              # -- Additional ingress annotations to add
+              annotations: {}
+              # -- EDC endpoints exposed by this ingress resource
+              endpoints:
+                - default
+                - management
+                - control
+                - protocol
+                - metrics
+                - observability
+              # -- Defines the [ingress class](https://kubernetes.io/docs/concepts/services-networking/ingress/#ingress-class)  to use
+              className: "nginx"
+              # -- TLS [tls class](https://kubernetes.io/docs/concepts/services-networking/ingress/#tls) applied to the ingress resource
+              tls:
+                # -- Enables TLS on the ingress resource
+                enabled: true
+                # -- If present overwrites the default secret name
+                secretName: "tls-secret"
+        dataplane:
+          enabled: true
+          endpoints:
+            default:
+              port: 8080
+              path: /consumer/api
+            public:
+              port: 8081
+              path: /consumer/api/public
+            control:
+              port: 8083
+              path: /consumer/api/dataplane/control
+            proxy:
+              port: 8186
+              path: /consumer/proxy
+            observability:
+              # -- port for incoming API calls
+              port: 8085
+              # -- observability api, provides /health /readiness and /liveness endpoints
+              path: /consumer/observability
+              # -- allow or disallow insecure access, i.e. access without authentication
+              insecure: true
+            metrics:
+              port: 9090
+              path: /consumer/metrics
+
+          ## Ingress declaration to expose the network service.
+          ingresses:
+            ## Public / Internet facing Ingress
+            - enabled: true
+              # -- The hostname to be used to precisely map incoming traffic onto the underlying network service
+              hostname: "materialpass.stable.demo.catena-x.net"
+              # -- Additional ingress annotations to add
+              annotations: {}
+              # -- EDC endpoints exposed by this ingress resource
+              endpoints:
+                - public
+              # -- Defines the [ingress class](https://kubernetes.io/docs/concepts/services-networking/ingress/#ingress-class)  to use
+              className: "nginx"
+              # -- TLS [tls class](https://kubernetes.io/docs/concepts/services-networking/ingress/#tls) applied to the ingress resource
+              tls:
+                # -- Enables TLS on the ingress resource
+                enabled: true
+                # -- If present overwrites the default secret name
+                secretName: "tls-secret"
+              ## Adds [cert-manager](https://cert-manager.io/docs/) annotations to the ingress resource
+              certManager:
+                # -- If preset enables certificate generation via cert-manager namespace scoped issuer
+                issuer: ""
+                # -- If preset enables certificate generation via cert-manager cluster-wide issuer
+                clusterIssuer: ""
+
+        postgresql:
+          username: dpp_user
+          password: dpp_password
+
+
+        vault:
+          hashicorp:
+            url: https://vault.demo.catena-x.net
+            token: s.nMWRzBOSupUC5iXyANzHC7Zo
+            paths:
+              secret:  /v1/material-pass
+              health: /v1/sys/health
+          secretNames:
+            transferProxyTokenSignerPrivateKey: ids-daps_key
+            transferProxyTokenSignerPublicKey: ids-daps_crt
+            transferProxyTokenEncryptionAesKey: edc-encryption-key
+
+        backendService:
+            httpProxyTokenReceiverUrl: "https://materialpass.stable.demo.catena-x.net/endpoint"
+  syncPolicy:
+    syncOptions:
+      - Replace=true

--- a/stable/3.2/dpp-edc-provider.yaml
+++ b/stable/3.2/dpp-edc-provider.yaml
@@ -1,0 +1,175 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: dpp-edc-provider
+  namespace: argocd
+spec:
+  project: project-material-pass
+  destination:
+    server: 'https://kubernetes.default.svc'
+    namespace: product-material-pass
+  source:
+    repoURL: 'https://eclipse-tractusx.github.io/charts/dev'
+    targetRevision: 0.5.0
+    chart: tractusx-connector
+    helm:
+      valueFiles:
+        - values.yaml
+      values: |
+        participant:
+          id: "BPNL00000000CBA5"
+
+        controlplane:
+          enabled: true
+          endpoints:
+            # -- default api for health checks, should not be added to any ingress
+            default:
+              # -- port for incoming api calls
+              port: 8080
+              # -- path for incoming api calls
+              path: /BPNL000000000000/api
+            # -- data management api, used by internal users, can be added to an ingress and must not be internet facing
+            management:
+              # -- port for incoming api calls
+              port: 8081
+              # -- path for incoming api calls
+              path: /BPNL000000000000/management
+              # -- authentication key, must be attached to each 'X-Api-Key' request header
+              authKey: password
+            # -- control api, used for internal control calls. can be added to the internal ingress, but should probably not
+            control:
+              # -- port for incoming api calls
+              port: 8083
+              # -- path for incoming api calls
+              path: /BPNL000000000000/control
+            # -- ids api, used for inter connector communication and must be internet facing
+            protocol:
+              # -- port for incoming api calls
+              port: 8084
+              # -- path for incoming api calls
+              path: /BPNL000000000000/api/v1/dsp
+            # -- metrics api, used for application metrics, must not be internet facing
+            metrics:
+              # -- port for incoming api calls
+              port: 9090
+              # -- path for incoming api calls
+              path: /BPNL000000000000/metrics
+            # -- observability api with unsecured access, must not be internet facing
+            observability:
+              # -- port for incoming API calls
+              port: 8085
+              # -- observability api, provides /health /readiness and /liveness endpoints
+              path: /BPNL000000000000/observability
+              # -- allow or disallow insecure access, i.e. access without authentication
+              insecure: true
+
+          ssi:
+            miw:
+              url: "https://managed-identity-wallets-new.stable.demo.catena-x.net"
+              authorityId: "BPNL00000003CRHK"
+            oauth:
+              tokenurl: "https://centralidp.stable.demo.catena-x.net/auth/realms/CX-Central/protocol/openid-connect/token"
+              client:
+                id: "sa3"
+                secretAlias: "stable-client-secret"
+            endpoint:
+              audience: https://materialpass.stable.demo.catena-x.net/consumer
+
+          ## Ingress declaration to expose the network service.
+          ingresses:
+            ## Public / Internet facing Ingress
+            - enabled: true
+              # -- The hostname to be used to precisely map incoming traffic onto the underlying network service
+              hostname: "materialpass.stable.demo.catena-x.net"
+              # -- Additional ingress annotations to add
+              annotations: {}
+              # -- EDC endpoints exposed by this ingress resource
+              endpoints:
+                - default
+                - management
+                - control
+                - protocol
+                - metrics
+                - observability
+              # -- Defines the [ingress class](https://kubernetes.io/docs/concepts/services-networking/ingress/#ingress-class)  to use
+              className: "nginx"
+              # -- TLS [tls class](https://kubernetes.io/docs/concepts/services-networking/ingress/#tls) applied to the ingress resource
+              tls:
+                # -- Enables TLS on the ingress resource
+                enabled: true
+                # -- If present overwrites the default secret name
+                secretName: "tls-secret"
+        dataplane:
+          enabled: true
+          endpoints:
+            default:
+              port: 8080
+              path: /BPNL000000000000/api
+            public:
+              port: 8081
+              path: /BPNL000000000000/api/public
+            control:
+              port: 8083
+              path: /BPNL000000000000/api/dataplane/control
+            proxy:
+              port: 8186
+              path: /BPNL000000000000/proxy
+            observability:
+              # -- port for incoming API calls
+              port: 8085
+              # -- observability api, provides /health /readiness and /liveness endpoints
+              path: /BPNL000000000000/observability
+              # -- allow or disallow insecure access, i.e. access without authentication
+              insecure: true
+            metrics:
+              port: 9090
+              path: /BPNL000000000000/metrics
+
+          ## Ingress declaration to expose the network service.
+          ingresses:
+            ## Public / Internet facing Ingress
+            - enabled: true
+              # -- The hostname to be used to precisely map incoming traffic onto the underlying network service
+              hostname: "materialpass.stable.demo.catena-x.net"
+              # -- Additional ingress annotations to add
+              annotations: {}
+              # -- EDC endpoints exposed by this ingress resource
+              endpoints:
+                - public
+              # -- Defines the [ingress class](https://kubernetes.io/docs/concepts/services-networking/ingress/#ingress-class)  to use
+              className: "nginx"
+              # -- TLS [tls class](https://kubernetes.io/docs/concepts/services-networking/ingress/#tls) applied to the ingress resource
+              tls:
+                # -- Enables TLS on the ingress resource
+                enabled: true
+                # -- If present overwrites the default secret name
+                secretName: "tls-secret"
+              ## Adds [cert-manager](https://cert-manager.io/docs/) annotations to the ingress resource
+              certManager:
+                # -- If preset enables certificate generation via cert-manager namespace scoped issuer
+                issuer: ""
+                # -- If preset enables certificate generation via cert-manager cluster-wide issuer
+                clusterIssuer: ""
+
+        postgresql:
+          username: dpp_user
+          password: dpp_password
+
+
+        vault:
+          hashicorp:
+            url: https://vault.demo.catena-x.net
+            token: s.nMWRzBOSupUC5iXyANzHC7Zo
+            paths:
+              secret:  /v1/material-pass
+              health: /v1/sys/health
+          secretNames:
+            transferProxyTokenSignerPrivateKey: ids-daps_key
+            transferProxyTokenSignerPublicKey: ids-daps_crt
+            transferProxyTokenEncryptionAesKey: edc-encryption-key
+
+        backendService:
+            httpProxyTokenReceiverUrl: "https://materialpass.stable.demo.catena-x.net/endpoint"
+  syncPolicy:
+    syncOptions:
+      - Replace=true

--- a/stable/3.2/dpp-registry.yaml
+++ b/stable/3.2/dpp-registry.yaml
@@ -1,0 +1,63 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: dpp-registry
+  namespace: argocd
+spec:
+  project: project-material-pass
+  destination:
+    server: 'https://kubernetes.default.svc'
+    namespace: product-material-pass
+  source:
+    repoURL: 'https://eclipse-tractusx.github.io/charts/dev'
+    targetRevision: 0.3.15
+    chart: registry
+    helm:
+      values: >-
+        provider-dtr:
+          registry:
+            host: materialpass.stable.demo.catena-x.net
+            ## If 'authentication' is set to false, no OAuth authentication is enforced
+            authentication: false
+            # Issuer url for the dtr (resource server),
+            # make sure that the url points to an externally resolvable hostname.
+            # If no value is committed, and the integrated Keycloak is enabled,
+            # the K8s internal service name is used, which is a problem, when
+            # validating the issuer claim in an access token
+            idpIssuerUri: https://centralidp.stable.demo.catena-x.net/auth/realms/CX-Central
+            idpClientId: Cl13-CX-Battery
+            tenantId: default-tenant
+            dataSource:
+              driverClassName: org.postgresql.Driver
+              sqlInitPlatform: pg
+              ## The url, user, and password parameter will be ignored if 'enablePostgres' is set to true.
+              ## In that case the postgresql auth parameters are used.
+              url: jdbc:postgresql://registry:5432
+              user: default-user
+              password: password
+            ingress:
+              enabled: true
+              tls: true
+              urlPrefix: /semantics/registry
+              className: nginx
+              annotations:
+                # Add annotations for the ingress, e.g.:
+                cert-manager.io/cluster-issuer: selfsigned-cluster-issuer
+                nginx.ingress.kubernetes.io/rewrite-target: /$2
+                nginx.ingress.kubernetes.io/use-regex: "true"
+                nginx.ingress.kubernetes.io/enable-cors: "true"
+                nginx.ingress.kubernetes.io/cors-allow-credentials: "true"
+                nginx.ingress.kubernetes.io/x-forwarded-prefix: /semantics/registry
+
+            # enables the default postgres database
+            enablePostgres: true
+            # enables the default keycloak identity provider
+            # relies on a postgres instance
+            enableKeycloak: false
+
+          postgresql:
+            auth:
+              username: default-user
+              password: password
+              database: default-database
+

--- a/stable/3.2/ids-data-exchange-test-service.yaml
+++ b/stable/3.2/ids-data-exchange-test-service.yaml
@@ -1,0 +1,43 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: ids-data-exchange-test-service.yaml
+  namespace: argocd
+spec:
+  project: project-essential-services
+  destination:
+    server: 'https://kubernetes.default.svc'
+    namespace: product-essential-services
+  source:
+    repoURL: 'https://eclipse-tractusx.github.io/charts/dev'
+    targetRevision: 1.0.9
+    chart: data-exchange
+    helm:
+      parameters:
+        - name: dataex.secret.e2edetsurl
+          value: 'https://dataex.stable.demo.catena-x.net'
+        - name: dataex.secret.edcapikey
+          value: jzWterGZLGxMT4QbRBh4WLlyqlmmSXqXBLGiOkZlS0fYmQUpv7
+        - name: dataex.secret.edcapikeyheader
+          value: X-Api-Key
+        - name: dataex.secret.edchostname
+          value: 'https://tsyste-f783465e-us.local.cx.dih-cloud.com'
+      values: |-
+        ingress:
+          enabled: true
+          annotations:
+            nginx.ingress.kubernetes.io/use-regex: "true"
+            cert-manager.io/cluster-issuer: "letsencrypt-prod"
+          className: "nginx"
+          host: "dataex.stable.demo.catena-x.net"
+          hosts:
+            - host: dataex.stable.demo.catena-x.net
+              paths:
+                - path: /
+                  pathType: ImplementationSpecific
+
+          tls:
+            enabled: true
+            secretName: tls-secret
+            host: "dataex.stable.demo.catena-x.net"
+

--- a/stable/3.2/ids-data-exchange-test-service.yaml
+++ b/stable/3.2/ids-data-exchange-test-service.yaml
@@ -1,7 +1,7 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
-  name: ids-data-exchange-test-service.yaml
+  name: ids-data-exchange-test-service
   namespace: argocd
 spec:
   project: project-essential-services

--- a/stable/3.2/ids-sdf.yaml
+++ b/stable/3.2/ids-sdf.yaml
@@ -1,0 +1,79 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: ids-sdf
+  namespace: argocd
+spec:
+  project: project-essential-services
+  destination:
+    server: 'https://kubernetes.default.svc'
+    namespace: product-essential-services
+  source:
+    repoURL: 'https://eclipse-tractusx.github.io/charts/dev'
+    targetRevision: 2.1.7
+    chart: sdfactory
+    helm:
+      parameters:
+        - name: sdfactory.secret.authServerUrl
+          value: 'https://centralidp.stable.demo.catena-x.net/auth'
+        - name: sdfactory.secret.clearingHouseClientId
+          value: dih-sa-test-catena-stable-7b66553047a0
+        - name: sdfactory.secret.clearingHouseClientSecret
+          value: 8aNJ59EyO9U1OT92IsAvb8t8IRSmNqKQ
+        - name: sdfactory.secret.clearingHouseRealm
+          value: carla
+        - name: sdfactory.secret.clearingHouseServerUrl
+          value: 'https://iam.test.dih-cloud.com'
+        - name: sdfactory.secret.clearingHouseUri
+          value: 'https://validation.test.dih-cloud.com/api/v1/compliance'
+        - name: sdfactory.secret.clientId
+          value: sa-cl5-custodian-1
+        - name: sdfactory.secret.clientSecret
+          value: hKE1KjZV3UprSsGDXUkgfyqpp8KxQwKm
+        - name: sdfactory.secret.custodianWalletUri
+          value: 'https://managed-identity-wallets-new.stable.demo.catena-x.net/api'
+        - name: sdfactory.secret.jwkSetUri
+          value: >-
+            https://centralidp.stable.demo.catena-x.net/auth/realms/CX-Central/protocol/openid-connect/certs
+        - name: sdfactory.secret.realm
+          value: CX-Central
+        - name: sdfactory.secret.resource
+          value: Cl2-CX-Portal
+      values: |-
+        ingress:
+          enabled: true
+          className: "nginx"
+          issuer: "letsencrypt-prod"
+          domain: ""
+          annotations:
+            cert-manager.io/cluster-issuer: letsencrypt-prod
+            kubernetes.io/ingress.class: nginx
+            nginx.ingress.kubernetes.io/configuration-snippet: |-
+              if ($http_origin ~* "http.?:\/\/(.*\.)?(localhost:3000|catena-x\.net|example\.com|idses-fe\.demo\.catena-x\.net).*$") {
+                set $allow_origin $http_origin;
+              }
+
+              add_header "Access-Control-Allow-Origin" "$http_origin" always;
+              add_header "Access-Control-Allow-Methods" "GET, PUT, POST, OPTIONS, DELETE" always;
+              add_header "Access-Control-Allow-Headers" "DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Authorization" always;
+              add_header "Access-Control-Expose-Headers" "Content-Range";
+
+              if ($request_method = 'OPTIONS') {
+                add_header "Access-Control-Allow-Origin" "$http_origin" always;
+                add_header "Access-Control-Allow-Methods" "GET, PUT, POST, OPTIONS, DELETE" always;
+                add_header "Access-Control-Allow-Headers" "DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Authorization" always;
+                add_header "Access-Control-Max-Age" "1728000" always;
+                add_header "Content-Type" "text/plain charset=UTF-8";
+                add_header "Content-Length" 0;
+                return 204;
+              }
+
+          hosts:
+            - host: "sdfactory.stable.demo.catena-x.net"
+              paths:
+                - path: /
+                  pathType: Prefix
+          tls:
+            - tlsName: sdfactory.stable.demo.catena-x.net-tls
+              hosts:
+                - sdfactory.stable.demo.catena-x.net

--- a/stable/3.2/managed-identity-wallet.yaml
+++ b/stable/3.2/managed-identity-wallet.yaml
@@ -1,0 +1,51 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: managed-identity-wallet
+  namespace: argocd
+spec:
+  project: project-managed-identity-wallets
+  destination:
+    server: 'https://kubernetes.default.svc'
+    namespace: product-managed-identity-wallets
+  source:
+    repoURL: 'https://eclipse-tractusx.github.io/charts/dev'
+    targetRevision: 0.1.0-rc.3
+    chart: managed-identity-wallet
+    helm:
+      parameters:
+        - name: keycloak.enabled
+          value: 'false'
+        - name: ingress.enabled
+          value: 'true'
+        - name: miw.host
+          value: managed-identity-wallets-new.stable.demo.catena-x.net
+        - name: miw.authorityWallet.bpn
+          value: BPNL00000003CRHK
+        - name: miw.keycloak.realm
+          value: CX-Central
+        - name: miw.database.name
+          value: miw
+        - name: miw.database.user
+          value: miw
+        - name: postgresql.auth.database
+          value: miw
+        - name: miw.keycloak.clientId
+          value: Cl5-CX-Custodian
+        - name: miw.keycloak.url
+          value: 'https://centralidp.stable.demo.catena-x.net/auth'
+        - name: image.tag
+          value: 0.2.0
+        - name: miw.ssi.enforceHttpsInDidWebResolution
+          value: 'true'
+      values: |-
+        ingress:
+          hosts:
+            - host: 'managed-identity-wallets-new.stable.demo.catena-x.net'
+              paths:
+                - path: /
+                  pathType: ImplementationSpecific
+          tls:
+            - secretName: ingress-secret
+              hosts:
+                - 'managed-identity-wallets-new.stable.demo.catena-x.net'

--- a/stable/3.2/portal-pgadmin4.yaml
+++ b/stable/3.2/portal-pgadmin4.yaml
@@ -1,0 +1,37 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: portal-pgadmin4
+  namespace: argocd
+spec:
+  project: project-portal
+  destination:
+    server: 'https://kubernetes.default.svc'
+    namespace: product-portal
+  source:
+    repoURL: 'https://github.com/catenax-ng/product-portal-tools.git'
+    path: charts/pgadmin4
+    targetRevision: main
+    plugin:
+      env:
+        - name: HELM_VALUES
+          value: |
+            pgadmin4:
+              secret:
+                password: "<path:portal/data/stable/pgadmin4#password>"
+              env:
+                email: portal@catena-x.net
+              existingSecret: secret-pgadmin4
+              ingress:
+                enabled: true
+                ingressClassName: "nginx"
+                annotations:
+                hosts:
+                  - host: portal-pgadmin4.stable.demo.catena-x.net
+                    paths:
+                    - path: /
+                      pathType: Prefix
+                tls:
+                  - hosts:
+                    - portal-pgadmin4.stable.demo.catena-x.net
+                    secretName: tls-secret

--- a/stable/3.2/portal.yaml
+++ b/stable/3.2/portal.yaml
@@ -1,0 +1,247 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: portal
+  namespace: argocd
+spec:
+  project: project-portal
+  destination:
+    server: 'https://kubernetes.default.svc'
+    namespace: product-portal
+  source:
+    repoURL: 'https://eclipse-tractusx.github.io/charts/dev'
+    targetRevision: 1.6.0
+    chart: portal
+    plugin:
+      env:
+        - name: HELM_VALUES
+          value: >
+            portalAddress: "https://portal.stable.demo.catena-x.net"
+
+            portalBackendAddress:
+            "https://portal-backend.stable.demo.catena-x.net"
+
+            centralidpAddress: "https://centralidp.stable.demo.catena-x.net"
+
+            sharedidpAddress: "https://sharedidp.stable.demo.catena-x.net"
+
+            semanticsAddress: "https://semantics.stable.demo.catena-x.net"
+
+            bpdmPartnersPoolAddress:
+            "https://business-partners.stable.demo.catena-x.net"
+
+            bpdmPortalGateAddress:
+            "https://business-partners.stable.demo.catena-x.net"
+
+            custodianAddress:
+            "https://managed-identity-wallets-new.stable.demo.catena-x.net"
+
+            sdfactoryAddress: "https://sdfactory.stable.demo.catena-x.net"
+
+            clearinghouseAddress: "https://validation.test.dih-cloud.com"
+
+            clearinghouseTokenAddress:
+            "https://iam.test.dih-cloud.com/realms/carla/protocol/openid-connect/token"
+
+            frontend:
+              ingress:
+                enabled: true
+                annotations:
+                  kubernetes.io/ingress.class: "nginx"
+                  nginx.ingress.kubernetes.io/rewrite-target: "/$$1"
+                  nginx.ingress.kubernetes.io/use-regex: "true"
+                  nginx.ingress.kubernetes.io/enable-cors: "true"
+                  nginx.ingress.kubernetes.io/cors-allow-origin: "http://localhost:3000, https://*.stable.demo.catena-x.net"
+                tls:
+                  - secretName: "tls-secret"
+                    hosts:
+                      - "portal.stable.demo.catena-x.net"
+                hosts:
+                  - host: "portal.stable.demo.catena-x.net"
+                    paths:
+                      - path: "/(.*)"
+                        pathType: "Prefix"
+                        backend:
+                          service: "portal"
+                          port: 8080
+                      - path: "/registration/(.*)"
+                        pathType: "Prefix"
+                        backend:
+                          service: "registration"
+                          port: 8080
+                      - path: "/((assets|documentation)/.*)"
+                        pathType: "Prefix"
+                        backend:
+                          service: "assets"
+                          port: 8080
+            backend:
+              ingress:
+                enabled: true
+                annotations:
+                  kubernetes.io/ingress.class: "nginx"
+                  nginx.ingress.kubernetes.io/use-regex: "true"
+                  nginx.ingress.kubernetes.io/enable-cors: "true"
+                  nginx.ingress.kubernetes.io/proxy-body-size: "8m"
+                  nginx.ingress.kubernetes.io/cors-allow-origin: "http://localhost:3000, https://*.stable.demo.catena-x.net"
+                tls:
+                  - secretName: "tls-secret"
+                    hosts:
+                      - "portal-backend.stable.demo.catena-x.net"
+                hosts:
+                  - host: "portal-backend.stable.demo.catena-x.net"
+                    paths:
+                      - path: "/api/registration"
+                        pathType: "Prefix"
+                        backend:
+                          service: "registration-service"
+                          port: 8080
+                      - path: "/api/administration"
+                        pathType: "Prefix"
+                        backend:
+                          service: "administration-service"
+                          port: 8080
+                      - path: "/api/notification"
+                        pathType: "Prefix"
+                        backend:
+                          service: "notification-service"
+                          port: 8080
+                      - path: "/api/apps"
+                        pathType: "Prefix"
+                        backend:
+                          service: "marketplace-app-service"
+                          port: 8080
+                      - path: "/api/services"
+                        pathType: "Prefix"
+                        backend:
+                          service: "services-service"
+                          port: 8080
+              keycloak:
+                central:
+                  clientId: "<path:portal/data/keycloak#central-client-id>"
+                  clientSecret: "<path:portal/data/stable/keycloak#central-client-secret>"
+                  dbConnection:
+                    password: "<path:portal/data/stable/keycloak#central-db-password>"
+                shared:
+                  clientId: "<path:portal/data/keycloak#shared-client-id>"
+                  clientSecret: "<path:portal/data/stable/keycloak#shared-client-secret>"
+              mailing:
+                host: "<path:portal/data/mailing#host>"
+                port: "<path:portal/data/mailing#port>"
+                user: "<path:portal/data/mailing#user>"
+                password: "<path:portal/data/mailing#password>"
+              registration:
+                logging:
+                  default: "Debug"
+                  bpdmLibrary: "Debug"
+                  registrationService: "Debug"
+                healthChecks:
+                  startup:
+                    tags:
+                    - name: "HEALTHCHECKS__0__TAGS__0"
+                      value: "keycloak"
+                    - name: "HEALTHCHECKS__0__TAGS__1"
+                      value: "portaldb"
+                swaggerEnabled: true
+              administration:
+                logging:
+                  default: "Debug"
+                  businessLogic: "Debug"
+                  sdfactoryLibrary: "Debug"
+                  bpdmLibrary: "Debug"
+                  custodianLibrary: "Debug"
+                healthChecks:
+                  startup:
+                    tags:
+                    - name: "HEALTHCHECKS__0__TAGS__0"
+                      value: "keycloak"
+                    - name: "HEALTHCHECKS__0__TAGS__1"
+                      value: "portaldb"
+                    - name: "HEALTHCHECKS__0__TAGS__2"
+                      value: "provisioningdb"
+                swaggerEnabled: true
+              provisioning:
+                sharedRealm:
+                  smtpServer:
+                    host: "<path:portal/data/mailing#host>"
+                    port: "<path:portal/data/mailing#port>"
+                    user: "<path:portal/data/mailing#user>"
+                    password: "<path:portal/data/mailing#password>"
+                    from: "<path:portal/data/mailing#from>"
+                    replyTo: "<path:portal/data/mailing#replyto>"
+              appmarketplace:
+                logging:
+                  default: "Debug"
+                  offersLibrary: "Debug"
+                healthChecks:
+                  startup:
+                    tags:
+                    - name: "HEALTHCHECKS__0__TAGS__0"
+                      value: "keycloak"
+                    - name: "HEALTHCHECKS__0__TAGS__1"
+                      value: "portaldb"
+                swaggerEnabled: true
+              portalmigrations:
+                logging:
+                  default: "Debug"
+                seeding:
+                  testDataEnvironments: "consortia"
+              notification:
+                healthChecks:
+                  startup:
+                    tags:
+                    - name: "HEALTHCHECKS__0__TAGS__0"
+                      value: "keycloak"
+                    - name: "HEALTHCHECKS__0__TAGS__1"
+                      value: "portaldb"
+                logging:
+                  default: "Debug"
+                swaggerEnabled: true
+              services:
+                logging:
+                  default: "Debug"
+                  offersLibrary: "Debug"
+                healthChecks:
+                  startup:
+                    tags:
+                    - name: "HEALTHCHECKS__0__TAGS__0"
+                      value: "keycloak"
+                    - name: "HEALTHCHECKS__0__TAGS__1"
+                      value: "portaldb"
+                swaggerEnabled: true
+              processesworker:
+                logging:
+                  default: "Debug"
+                  processesLibrary: "Debug"
+                  bpdmLibrary: "Debug"
+                  clearinghouseLibrary: "Debug"
+                  custodianLibrary: "Debug"
+                  sdfactoryLibrary: "Debug"
+                  offerProvider: "Debug"
+                bpdm:
+                  clientId: "<path:portal/data/processes-worker#bpdm-client-id>"
+                  clientSecret: "<path:portal/data/stable/processes-worker#bpdm-client-secret>"
+                clearinghouse:
+                  clientId: "<path:portal/data/stable/processes-worker#clearinghouse-client-id>"
+                  clientSecret: "<path:portal/data/stable/processes-worker#clearinghouse-client-secret>"
+                custodian:
+                  clientId: "<path:portal/data/processes-worker#custodian-client-id>"
+                  clientSecret: "<path:portal/data/stable/processes-worker#custodian-client-secret>"
+                sdfactory:
+                  issuerBpn: "BPNL00000003CRHK"
+                  clientId: "<path:portal/data/processes-worker#sdfactory-client-id>"
+                  clientSecret: "<path:portal/data/stable/processes-worker#sdfactory-client-secret>"
+                offerprovider:
+                  clientId: "<path:portal/data/processes-worker#offerprovider-client-id>"
+                  clientSecret: "<path:portal/data/stable/processes-worker#offerprovider-client-secret>"
+            postgresql:
+              auth:
+                password: "<path:portal/data/stable/postgres#postgres-password>"
+                replicationPassword: "<path:portal/data/stable/postgres#replication-password>"
+                portalPassword: "<path:portal/data/stable/postgres#portal-password>"
+                provisioningPassword: "<path:portal/data/stable/postgres#provisioning-password>"
+              primary:
+                extendedConfiguration: |
+                  max_connections = 200
+              readReplicas:
+                extendedConfiguration: |
+                  max_connections = 200

--- a/stable/3.2/portal.yaml
+++ b/stable/3.2/portal.yaml
@@ -17,31 +17,16 @@ spec:
         - name: HELM_VALUES
           value: >
             portalAddress: "https://portal.stable.demo.catena-x.net"
-
-            portalBackendAddress:
-            "https://portal-backend.stable.demo.catena-x.net"
-
+            portalBackendAddress: "https://portal-backend.stable.demo.catena-x.net"
             centralidpAddress: "https://centralidp.stable.demo.catena-x.net"
-
             sharedidpAddress: "https://sharedidp.stable.demo.catena-x.net"
-
             semanticsAddress: "https://semantics.stable.demo.catena-x.net"
-
-            bpdmPartnersPoolAddress:
-            "https://business-partners.stable.demo.catena-x.net"
-
-            bpdmPortalGateAddress:
-            "https://business-partners.stable.demo.catena-x.net"
-
-            custodianAddress:
-            "https://managed-identity-wallets-new.stable.demo.catena-x.net"
-
+            bpdmPartnersPoolAddress: "https://business-partners.stable.demo.catena-x.net"
+            bpdmPortalGateAddress: "https://business-partners.stable.demo.catena-x.net"
+            custodianAddress: "https://managed-identity-wallets-new.stable.demo.catena-x.net"
             sdfactoryAddress: "https://sdfactory.stable.demo.catena-x.net"
-
             clearinghouseAddress: "https://validation.test.dih-cloud.com"
-
-            clearinghouseTokenAddress:
-            "https://iam.test.dih-cloud.com/realms/carla/protocol/openid-connect/token"
+            clearinghouseTokenAddress: "https://iam.test.dih-cloud.com/realms/carla/protocol/openid-connect/token"
 
             frontend:
               ingress:

--- a/stable/3.2/provider-agent.yaml
+++ b/stable/3.2/provider-agent.yaml
@@ -1,0 +1,30 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: provider-agent
+  namespace: argocd
+spec:
+  project: project-knowledge
+  destination:
+    server: 'https://kubernetes.default.svc'
+    namespace: product-knowledge
+  source:
+    repoURL: 'https://eclipse-tractusx.github.io/charts/dev'
+    targetRevision: 1.9.8
+    chart: provisioning-agent
+    helm:
+      parameters:
+        - name: securityContext.readOnlyRootFilesystem
+          value: 'false'
+        - name: securityContext.runAsUser
+          value: '999'
+        - name: securityContext.runAsGroup
+          value: '999'
+        - name: podSecurityContext.runAsUser
+          value: '999'
+        - name: podSecurityContext.runAsGroup
+          value: '999'
+        - name: podSecurityContext.fsGroup
+          value: '999'
+        - name: bindings.dtc.mappping
+          value: "[PrefixDeclaration]\ncx-common:          https://w3id.org/catenax/ontology/common#\ncx-core:            https://w3id.org/catenax/ontology/core#\ncx-vehicle:         https://w3id.org/catenax/ontology/vehicle#\ncx-reliability:     https://w3id.org/catenax/ontology/reliability#\nuuid:\t\t        urn:uuid:\nbpnl:\t\t        bpn:legal:\nowl:\t\t        http://www.w3.org/2002/07/owl#\nrdf:\t\t        http://www.w3.org/1999/02/22-rdf-syntax-ns#\nxml:\t\t        http://www.w3.org/XML/1998/namespace\nxsd:\t\t        http://www.w3.org/2001/XMLSchema#\njson:               https://json-schema.org/draft/2020-12/schema#\nobda:\t\t        https://w3id.org/obda/vocabulary#\nrdfs:\t\t        http://www.w3.org/2000/01/rdf-schema#\noem:                urn:oem:\n\n[MappingDeclaration] @collection [[\nmappingId\tdtc-meta\ntarget\t\tbpnl:{bpnl} rdf:type cx-common:BusinessPartner ; cx-core:id {bpnl}^^xsd:string . \nsource\t\tSELECT distinct \"bpnl\" FROM \"dtc\".\"meta\"\n\nmappingId\tdtc-content\ntarget\t\toem:Analysis/{id} rdf:type cx-reliability:Analysis ; cx-core:id {code}^^xsd:string ; cx-core:name {description}^^xsd:string .\nsource\t\tSELECT * FROM \"dtc\".\"content\"\n\nmappingId\tdtc-part\ntarget\t\toem:Part/{entityGuid} rdf:type cx-vehicle:Part ; cx-core:id {enDenomination}^^xsd:string ; cx-core:name {classification}^^xsd:string .\nsource\t\tSELECT * FROM \"dtc\".\"part\"\n\nmappingId\tdtc-meta-part\ntarget\t\toem:Part/{entityGuid} cx-vehicle:manufacturer bpnl:{bpnl}. \nsource\t\tSELECT \"bpnl\",\"entityGuid\" FROM \"dtc\".\"part\"\n\nmappingId\tdtc-part-content\ntarget\t\toem:Analysis/{dtc_id} cx-reliability:analysedObject oem:Part/{part_entityGuid}. \nsource\t\tSELECT \"part_entityGuid\",\"dtc_id\" FROM \"dtc\".\"content_part\"\n\n]]\n"

--- a/stable/3.2/remoting-agent.yaml
+++ b/stable/3.2/remoting-agent.yaml
@@ -1,0 +1,18 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: remoting-agent
+  namespace: argocd
+spec:
+  project: project-knowledge
+  destination:
+    server: 'https://kubernetes.default.svc'
+    namespace: product-knowledge
+  source:
+    repoURL: 'https://eclipse-tractusx.github.io/charts/dev'
+    targetRevision: 1.9.8
+    chart: remoting-agent
+    helm:
+      parameters:
+        - name: image.pullPolicy
+          value: Always

--- a/stable/3.2/semantic-services.yaml
+++ b/stable/3.2/semantic-services.yaml
@@ -1,0 +1,69 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: semantic-services
+  namespace: argocd
+spec:
+  project: project-semantics
+  destination:
+    server: 'https://kubernetes.default.svc'
+    namespace: product-semantics
+  source:
+    repoURL: 'https://eclipse-tractusx.github.io/charts/dev'
+    targetRevision: 0.1.29
+    chart: semantic-hub
+    plugin:
+      env:
+        - name: HELM_VALUES
+          value: |
+            hub:
+              enableKeycloak: false
+              imagePullPolicy: Always
+              replicaCount: 1
+              containerPort: 4242
+              ## Use in-memory triple store that is not persistent
+              embeddedTripleStore: false
+              host: semantics.stable.demo.catena-x.net
+              ## If 'authentication' is set to false, no OAuth authentication is enforced
+              authentication: true
+              idpIssuerUri: https://centralidp.stable.demo.catena-x.net/auth/realms/CX-Central
+              idpClientId: Cl3-CX-Semantic
+              ## Ignored if 'graphdb.enabled' is set to true
+              graphdbBaseUrl: http://graphdb:3030
+              service:
+                port: 8080
+                type: ClusterIP
+              ingress:
+                ## Enable ingress for the Semantic Hub
+                enabled: true
+                ## Enable TLS (e.g. by using cert-manager)
+                tls: true
+                ## The secret name that contains the necessary 'tls.crt' and 'tls.key' entries
+                ## When using cert-manager this secret is created automatically
+                urlPrefix: /hub
+                tlsSecretName: hub-certificate-secret
+                className: nginx
+                annotations:
+                  cert-manager.io/cluster-issuer: letsencrypt-prod
+                  nginx.ingress.kubernetes.io/rewrite-target: /$$2
+                  nginx.ingress.kubernetes.io/use-regex: "true"
+                  nginx.ingress.kubernetes.io/enable-cors: "true"
+                  nginx.ingress.kubernetes.io/cors-allow-credentials: "true"
+                  nginx.ingress.kubernetes.io/x-forwarded-prefix: /hub
+            graphdb:
+              ## Include Fuski deployment or deploy separately
+              enabled: true
+              image: ghcr.io/catenax-ng/jena-fuseki:4.7.0
+              storageClassName: azurefile
+              pvcAccessModes:
+                - ReadWriteOnce
+              resources:
+                limits:
+                  memory: "1024Mi"
+                requests:
+                  memory: "512Mi"
+              service:
+                port: 3030
+            enableKeycloak: false
+            keycloak:
+              enabled: false

--- a/stable/3.2/sharedidp.yaml
+++ b/stable/3.2/sharedidp.yaml
@@ -1,0 +1,100 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: sharedidp
+  namespace: argocd
+spec:
+  project: project-portal
+  destination:
+    server: 'https://kubernetes.default.svc'
+    namespace: product-portal
+  source:
+    repoURL: 'https://eclipse-tractusx.github.io/charts/dev'
+    targetRevision: 1.2.0
+    chart: sharedidp
+    plugin:
+      env:
+        - name: HELM_VALUES
+          value: |
+            keycloak:
+              extraVolumes:
+                - name: themes-catenax-shared
+                  emptyDir: {}
+                - name: themes-catenax-shared-portal
+                  emptyDir: {}
+                - name: realms
+                  emptyDir: {}
+                - name: realm-secrets
+                  secret:
+                    secretName: secret-sharedidp-realms
+              extraVolumeMounts:
+                - name: themes-catenax-shared
+                  mountPath: "/opt/bitnami/keycloak/themes/catenax-shared"
+                - name: themes-catenax-shared-portal
+                  mountPath: "/opt/bitnami/keycloak/themes/catenax-shared-portal"
+                - name: realms
+                  mountPath: "/realms"
+                - name: realm-secrets
+                  mountPath: "/secrets"
+              initContainers:
+                - name: import
+                  image: tractusx/portal-iam-consortia:v1.2.0
+                  imagePullPolicy: Always
+                  command:
+                    - sh
+                  args:
+                    - -c
+                    - |
+                      echo "Copying themes-catenax-shared..."
+                      cp -R /import/themes/catenax-shared/* /themes-catenax-shared
+                      echo "Copying themes-catenax-shared-portal..."
+                      cp -R /import/themes/catenax-shared-portal/* /themes-catenax-shared-portal
+                      echo "Copying realms..."
+                      cp -R /import/catenax-shared/stable/realms/* /realms
+                      echo "Copying realms-secrets..."
+                      cp /secrets/* /realms
+                  volumeMounts:
+                  - name: themes-catenax-shared
+                    mountPath: "/themes-catenax-shared"
+                  - name: themes-catenax-shared-portal
+                    mountPath: "/themes-catenax-shared-portal"
+                  - name: realms
+                    mountPath: "/realms"
+                  - name: realm-secrets
+                    mountPath: "/secrets"
+              ingress:
+                enabled: true
+                ingressClassName: nginx
+                hostname: sharedidp.stable.demo.catena-x.net
+                annotations:
+                  cert-manager.io/cluster-issuer: letsencrypt-prod
+                  nginx.ingress.kubernetes.io/cors-allow-credentials: "true"
+                  nginx.ingress.kubernetes.io/cors-allow-methods: PUT, GET, POST, OPTIONS
+                  nginx.ingress.kubernetes.io/cors-allow-origin: https://sharedidp.stable.demo.catena-x.net, http://localhost:3000
+                  nginx.ingress.kubernetes.io/enable-cors: "true"
+                  nginx.ingress.kubernetes.io/proxy-buffer-size: 128k
+                  nginx.ingress.kubernetes.io/proxy-buffering: "on"
+                  nginx.ingress.kubernetes.io/proxy-buffers-number: "20"
+                  nginx.ingress.kubernetes.io/use-regex: "true"
+                tls: true
+            secrets:
+              auth:
+                existingSecret:
+                  adminpassword: "<path:portal/data/stable/iam/sharedidp-keycloak#admin-password>"
+                  managementpassword: "<path:portal/data/stable/iam/sharedidp-keycloak#management-password>"
+              postgresql:
+                auth:
+                  existingSecret:
+                    postgrespassword: "<path:portal/data/stable/iam/sharedidp-postgres#postgres-password>"
+                    password: "<path:portal/data/stable/iam/sharedidp-postgres#password>"
+                    replicationPassword: "<path:portal/data/stable/iam/sharedidp-postgres#replication-password>"
+              realmuser:
+                enabled: true
+                cxtestaccessuser: "<path:portal/data/iam/sharedidp-user#CX-Test-Access-users-0.json>"
+                company1user: "<path:portal/data/iam/sharedidp-user#Company-1-users-0.json>"
+                company2user: "<path:portal/data/iam/sharedidp-user#Company-2-users-0.json>"
+                securitycompany: "<path:portal/data/iam/sharedidp-user#Security-Company-users-0.json>"
+                cxoperator: "<path:portal/data/iam/sharedidp-user#CX-Operator-users-0.json>"
+                serviceprovider: "<path:portal/data/iam/sharedidp-user#Service-Provider-users-0.json>"
+                appprovider: "<path:portal/data/iam/sharedidp-user#App-Provider-users-0.json>"
+                chart: sharedidp

--- a/stable/3.2/tx-dt-registry-stable-a.yaml
+++ b/stable/3.2/tx-dt-registry-stable-a.yaml
@@ -1,0 +1,34 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: tx-dt-registry-stable-a
+  namespace: argocd
+spec:
+  project: project-traceability-foss
+  destination:
+    server: 'https://kubernetes.default.svc'
+    namespace: product-traceability-foss
+  source:
+    repoURL: 'https://eclipse-tractusx.github.io/charts/dev'
+    targetRevision: 0.3.22
+    chart: registry
+    helm:
+      parameters:
+        - name: enableKeycloak
+          value: 'false'
+      values: |
+        registry:
+          authentication: false
+          idpIssuerUri: https://centralidp.stable.demo.catena-x.net/auth/realms/CX-Central
+          host: trace-x-registry-stable-a.stable.demo.catena-x.net
+          ingress:
+            enabled: true
+            tls: true
+            className: nginx
+            urlPrefix: /semantics/registry
+            annotations:
+              nginx.ingress.kubernetes.io/enable-cors: "true"
+              nginx.ingress.kubernetes.io/cors-allow-credentials: "true"
+              nginx.ingress.kubernetes.io/rewrite-target: /$2
+              nginx.ingress.kubernetes.io/use-regex: "true"
+

--- a/stable/3.2/tx-dt-registry-stable-b.yaml
+++ b/stable/3.2/tx-dt-registry-stable-b.yaml
@@ -1,0 +1,34 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: tx-dt-registry-stable-b
+  namespace: argocd
+spec:
+  project: project-traceability-foss
+  destination:
+    server: 'https://kubernetes.default.svc'
+    namespace: product-traceability-foss
+  source:
+    repoURL: 'https://eclipse-tractusx.github.io/charts/dev'
+    targetRevision: 0.3.22
+    chart: registry
+    helm:
+      parameters:
+        - name: enableKeycloak
+          value: 'false'
+      values: |
+        registry:
+          authentication: false
+          idpIssuerUri: https://centralidp.stable.demo.catena-x.net/auth/realms/CX-Central
+          host: trace-x-registry-stable-b.stable.demo.catena-x.net
+          ingress:
+            enabled: true
+            tls: true
+            className: nginx
+            urlPrefix: /semantics/registry
+            annotations:
+              nginx.ingress.kubernetes.io/enable-cors: "true"
+              nginx.ingress.kubernetes.io/cors-allow-credentials: "true"
+              nginx.ingress.kubernetes.io/rewrite-target: /$2
+              nginx.ingress.kubernetes.io/use-regex: "true"
+

--- a/stable/3.2/tx-edc-provider-stable-a.yaml
+++ b/stable/3.2/tx-edc-provider-stable-a.yaml
@@ -1,7 +1,7 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
-  name: tx-edc-registry-stable-a
+  name: tx-edc-provider-stable-a
   namespace: argocd
 spec:
   project: project-traceability-foss

--- a/stable/3.2/tx-edc-provider-stable-a.yaml
+++ b/stable/3.2/tx-edc-provider-stable-a.yaml
@@ -1,0 +1,109 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: tx-edc-registry-stable-a
+  namespace: argocd
+spec:
+  project: project-traceability-foss
+  destination:
+    server: 'https://kubernetes.default.svc'
+    namespace: product-traceability-foss
+  source:
+    repoURL: 'https://eclipse-tractusx.github.io/charts/dev'
+    targetRevision: 0.5.0
+    chart: tractusx-connector
+    plugin:
+      env:
+        - name: HELM_VALUES
+          value: |
+            install:
+              postgresql: true
+              vault: false
+            enabled: true
+            nameOverride: "tx-edc-provider-stable-a"
+            fullnameOverride: "tx-edc-provider-stable-a"
+            participant:
+              id: BPNL00000003CML1
+            controlplane:
+              ingresses:
+                - enabled: true
+                  hostname: "trace-x-edc-stable-a.stable.demo.catena-x.net"
+                  annotations:
+                    nginx.ingress.kubernetes.io/ssl-passthrough: "false"
+                    nginx.ingress.kubernetes.io/backend-protocol: "HTTP"
+                    nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
+                  endpoints:
+                    - protocol
+                    - management
+                  tls:
+                    enabled: true
+                    secretName: tls-secret
+              ssi:
+                miw:
+                  url: '<path:traceability-foss/data/stable-a/edc/wallet#ssi.miw.url>'
+                  authorityId: '<path:traceability-foss/data/stable-a/edc/wallet#ssi.miw.authorityId>'
+                oauth:
+                  tokenurl: '<path:traceability-foss/data/stable-a/edc/wallet#ssi.oauth.tokenurl>'
+                  client:
+                    id: '<path:traceability-foss/data/stable-a/edc/wallet#ssi.oauth.client.id>'
+                    secretAlias: edc-miw-keycloak-secret-stable-a
+              endpoints:
+                management:
+                  authKey: '<path:traceability-foss/data/stable-a/edc/controlplane#edc.api.control.auth.apikey.value>'
+              resources:
+                limits:
+                  cpu: 400m
+                  memory: 1.5Gi
+                requests:
+                  cpu: 200m
+                  memory: 1.5Gi
+            dataplane:
+              ingresses:
+                - enabled: true
+                  hostname: "trace-x-edc-stable-a-dataplane.stable.demo.catena-x.net"
+                  annotations:
+                    nginx.ingress.kubernetes.io/ssl-passthrough: "false"
+                    nginx.ingress.kubernetes.io/backend-protocol: "HTTP"
+                    nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
+                  endpoints:
+                    - public
+                  className: "nginx"
+                  tls:
+                    enabled: true
+                    secretName: tls-secret
+
+              resources:
+                limits:
+                  cpu: 200m
+                  memory: 512Mi
+                requests:
+                  cpu: 100m
+                  memory: 512Mi
+
+            backendService:
+              httpProxyTokenReceiverUrl: "https://traceability-stable-a.stable.demo.catena-x.net/api/callback/endpoint-data-reference"
+
+            postgresql:
+              enabled: true
+              auth:
+                username: '<path:traceability-foss/data/stable-a/edc/database#user>'
+                password: '<path:traceability-foss/data/stable-a/edc/database#password>'
+              username: '<path:traceability-foss/data/stable-a/edc/database#user>'
+              password: '<path:traceability-foss/data/stable-a/edc/database#password>'
+              jdbcUrl: "jdbc:postgresql://{{ .Release.Name }}-postgresql:5432/edc"
+
+            vault:
+              hashicorp:
+                url: "https://vault.demo.catena-x.net"
+                token: '<path:traceability-foss/data/stable-a/edc#edc.vault.hashicorp.token>'
+                timeout: 30
+                healthCheck:
+                  enabled: true
+                  standbyOk: true
+                paths:
+                  secret: /v1/traceability-foss
+                  health: /v1/sys/health
+              secretNames:
+                transferProxyTokenSignerPrivateKey: daps-cert-key-stable-a
+                transferProxyTokenSignerPublicKey: daps-cert-stable-a
+                transferProxyTokenEncryptionAesKey: token-signer-aes-key

--- a/stable/3.2/tx-edc-provider-stable-b.yaml
+++ b/stable/3.2/tx-edc-provider-stable-b.yaml
@@ -1,7 +1,7 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
-  name: tx-edc-registry-stable-b
+  name: tx-edc-provider-stable-b
   namespace: argocd
 spec:
   project: project-traceability-foss

--- a/stable/3.2/tx-edc-provider-stable-b.yaml
+++ b/stable/3.2/tx-edc-provider-stable-b.yaml
@@ -1,0 +1,110 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: tx-edc-registry-stable-b
+  namespace: argocd
+spec:
+  project: project-traceability-foss
+  destination:
+    server: 'https://kubernetes.default.svc'
+    namespace: product-traceability-foss
+  source:
+    repoURL: 'https://eclipse-tractusx.github.io/charts/dev'
+    targetRevision: 0.5.0
+    chart: tractusx-connector
+    plugin:
+      env:
+        - name: HELM_VALUES
+          value: |
+            install:
+              postgresql: true
+              vault: false
+            enabled: true
+            nameOverride: "tx-edc-provider-stable-b"
+            fullnameOverride: "tx-edc-provider-stable-b"
+            participant:
+              id: BPNL00000003CNKC
+            controlplane:
+              ingresses:
+                - enabled: true
+                  hostname: "trace-x-edc-stable-b.stable.demo.catena-x.net"
+                  annotations:
+                    nginx.ingress.kubernetes.io/ssl-passthrough: "false"
+                    nginx.ingress.kubernetes.io/backend-protocol: "HTTP"
+                    nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
+                  endpoints:
+                    - protocol
+                    - management
+                  tls:
+                    enabled: true
+                    secretName: tls-secret
+              ssi:
+                miw:
+                  url: '<path:traceability-foss/data/stable-b/edc/wallet#ssi.miw.url>'
+                  authorityId: '<path:traceability-foss/data/stable-b/edc/wallet#ssi.miw.authorityId>'
+                oauth:
+                  tokenurl: '<path:traceability-foss/data/stable-b/edc/wallet#ssi.oauth.tokenurl>'
+                  client:
+                    id: '<path:traceability-foss/data/stable-b/edc/wallet#ssi.oauth.client.id>'
+                    secretAlias: edc-miw-keycloak-secret-stable-b
+              endpoints:
+                management:
+                  authKey: '<path:traceability-foss/data/stable-b/edc/controlplane#edc.api.control.auth.apikey.value>'
+              resources:
+                limits:
+                  cpu: 400m
+                  memory: 1.5Gi
+                requests:
+                  cpu: 200m
+                  memory: 1.5Gi
+            dataplane:
+              ingresses:
+                - enabled: true
+                  hostname: "trace-x-edc-stable-b-dataplane.stable.demo.catena-x.net"
+                  annotations:
+                    nginx.ingress.kubernetes.io/ssl-passthrough: "false"
+                    nginx.ingress.kubernetes.io/backend-protocol: "HTTP"
+                    nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
+                  endpoints:
+                    - public
+                  className: "nginx"
+                  tls:
+                    enabled: true
+                    secretName: tls-secret
+
+              resources:
+                limits:
+                  cpu: 200m
+                  memory: 512Mi
+                requests:
+                  cpu: 100m
+                  memory: 512Mi
+
+            backendService:
+              httpProxyTokenReceiverUrl: "https://traceability-stable-b.stable.demo.catena-x.net/api/callback/endpoint-data-reference"
+
+            postgresql:
+              enabled: true
+              auth:
+                username: '<path:traceability-foss/data/stable-b/edc/database#user>'
+                password: '<path:traceability-foss/data/stable-b/edc/database#password>'
+              username: '<path:traceability-foss/data/stable-b/edc/database#user>'
+              password: '<path:traceability-foss/data/stable-b/edc/database#password>'
+              jdbcUrl: "jdbc:postgresql://{{ .Release.Name }}-postgresql:5432/edc"
+
+            vault:
+              hashicorp:
+                url: "https://vault.demo.catena-x.net"
+                token: '<path:traceability-foss/data/stable-b/edc#edc.vault.hashicorp.token>'
+                timeout: 30
+                healthCheck:
+                  enabled: true
+                  standbyOk: true
+                paths:
+                  secret: /v1/traceability-foss
+                  health: /v1/sys/health
+              secretNames:
+                transferProxyTokenSignerPrivateKey: daps-cert-key-stable-b
+                transferProxyTokenSignerPublicKey: daps-cert-stable-b
+                transferProxyTokenEncryptionAesKey: token-signer-aes-key
+

--- a/stable/3.2/tx-stable-a.yaml
+++ b/stable/3.2/tx-stable-a.yaml
@@ -1,0 +1,375 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: tx-stable-a
+  namespace: argocd
+spec:
+  project: project-traceability-foss
+  destination:
+    server: 'https://kubernetes.default.svc'
+    namespace: product-traceability-foss
+  source:
+    repoURL: 'https://eclipse-tractusx.github.io/charts/dev'
+    targetRevision: 1.3.18
+    chart: traceability-foss
+    plugin:
+      env:
+        - name: HELM_VALUES
+          value: |
+            global:
+              enablePrometheus: false
+              enableGrafana: false
+            frontend:
+              image:
+                repository: ghcr.io/catenax-ng/tx-traceability-foss
+                tag: 6.0.1-rc4
+                CATENAX_PORTAL_API_URL: '<path:traceability-foss/data/stable-a/frontend#catenax_portal_api_url>'
+                CATENAX_PORTAL_KEYCLOAK_URL: '<path:traceability-foss/data/stable-a/frontend#catenax_portal_keycloak_url>'
+                CATENAX_PORTAL_BACKEND_DOMAIN: '<path:traceability-foss/data/stable-a/frontend#catenax_portal_backend_domain>'
+                CATENAX_PORTAL_URL: '<path:traceability-foss/data/stable-a/frontend#catenax_portal_url>'
+                CATENAX_PORTAL_CLIENT_ID: '<path:traceability-foss/data/stable-a/frontend#catenax_portal_client_id>'
+              nameOverride: "tx-frontend-stable-a"
+              fullnameOverride: "tx-frontend-stable-a"
+              ingress:
+                enabled: true
+                className: "nginx"
+                annotations:
+                  cert-manager.io/cluster-issuer: letsencrypt-prod
+                hosts:
+                  - host: "traceability-portal-stable-a.stable.demo.catena-x.net"
+                    paths:
+                      - path: /
+                        pathType: ImplementationSpecific
+                tls:
+                  - hosts:
+                      - "traceability-portal-stable-a.stable.demo.catena-x.net"
+                    secretName: "traceability-portal-stable-a.stable.demo.catena-x.net-tls"
+            backend:
+              image:
+                repository: ghcr.io/catenax-ng/tx-traceability-foss
+                tag: 6.0.1-rc4
+              nameOverride: "tx-backend-stable-a"
+              fullnameOverride: "tx-backend-stable-a"
+              podSecurityContext:
+                runAsUser: 10001
+                seccompProfile:
+                  type: RuntimeDefault
+              securityContext:
+                allowPrivilegeEscalation: false
+                runAsNonRoot: true
+                runAsUser: 10001
+                runAsGroup: 3000
+                capabilities:
+                  drop:
+                    - ALL
+                readOnlyRootFilesystem: false
+              resources:
+                limits:
+                  cpu: 500m
+                  memory: 512Mi
+                requests:
+                  cpu: 100m
+                  memory: 512Mi
+              springprofile: dev
+              ingress:
+                enabled: true
+                className: "nginx"
+                annotations:
+                  nginx.ingress.kubernetes.io/backend-protocol: HTTP
+                hosts:
+                  - host: "traceability-stable-a.stable.demo.catena-x.net"
+                    paths:
+                      - path: /
+                        pathType: ImplementationSpecific
+                tls:
+                  - hosts:
+                      - "traceability-stable-a.stable.demo.catena-x.net"
+                    secretName: tls-secret
+
+              traceability:
+                bpn: "BPNL00000003CML1"
+                url: "https://traceability-stable-a.stable.demo.catena-x.net"
+              datasource:
+                url: jdbc:postgresql://tx-backend-postgresql-stable-a:5432/trace
+                username: trace
+                password: '<path:traceability-foss/data/stable-a/database#tracePassword>'
+              oauth2:
+                clientId: '<path:traceability-foss/data/stable-a/keycloak/oauth2#clientId>'
+                clientSecret: '<path:traceability-foss/data/stable-a/keycloak/oauth2#clientSecret>'
+                clientTokenUri: "https://centralidp.stable.demo.catena-x.net/auth/realms/CX-Central/protocol/openid-connect/token"
+                jwkSetUri: "https://centralidp.stable.demo.catena-x.net/auth/realms/CX-Central/protocol/openid-connect/certs"
+                resourceClient: "app10"
+              edc:
+                apiKey: "<path:traceability-foss/data/stable-a/edc/controlplane#edc.api.control.auth.apikey.value>"
+                providerUrl: "https://tx-edc-consumer-stable-a-controlplane.stable.demo.catena-x.net"
+                callbackUrl: "http://tx-irs-stable-a:8181/internal/endpoint-data-reference"
+                callbackUrlEdcClient: "https://traceability-stable-a.stable.demo.catena-x.net/api/internal/endpoint-data-reference"
+                dataEndpointUrl: "https://tx-edc-consumer-stable-a-controlplane.stable.demo.catena-x.net/management"
+              discoveryfinder:
+                baseUrl: "https://semantics.stable.demo.catena-x.net/discoveryfinder/api/administration/connectors/discovery/search"
+              config:
+                allowedCorsOriginFirst: "http://localhost:4200/"
+                allowedCorsOriginSecond: "https://traceability-portal-stable-a.stable.demo.catena-x.net/"
+              irs:
+                baseUrl: "https://tx-irs-stable-a.stable.demo.catena-x.net"
+              registry:
+                urlWithPath: "https://trace-x-registry-stable-a.stable.demo.catena-x.net/semantics/registry/api/v3.0"
+              portal:
+                baseUrl: "https://portal-backend.stable.demo.catena-x.net/api"
+              dependencies:
+                enabled: true
+                irs: "tx-irs-stable-a"
+                edc: "tx-edc-consumer-stable-a"
+            pgadmin4:
+              nameOverride: "tx-pgadmin-stable-a"
+              fullnameOverride: "tx-pgadmin-stable-a"
+              enabled: true
+              strategy:
+                type: Recreate
+              networkPolicy:
+                enabled: false
+              ingress:
+                enabled: true
+                annotations:
+                  kubernetes.io/ingress.class: nginx
+                  nginx.ingress.kubernetes.io/backend-protocol: HTTP
+                hosts:
+                  - host: tx-pgadmin-stable-a.stable.demo.catena-x.net
+                    paths:
+                      - path: /
+                        pathType: Prefix
+                tls:
+                  - hosts:
+                      - tx-pgadmin-stable-a.stable.demo.catena-x.net
+                    secretName: tls-secret
+              env:
+                email: pgadmin4@trace.foss
+                password: "<path:traceability-foss/data/stable-a/database#pgadminPassword>"
+                variables:
+                  - name: PGADMIN_CONFIG_UPGRADE_CHECK_ENABLED
+                    value: "False"
+              resources:
+                limits:
+                  cpu: 200m
+                  memory: 512Gi
+                requests:
+                  cpu: 100m
+                  memory: 512Mi
+            postgresql:
+              enabled: true
+              nameOverride: "tx-backend-postgresql-stable-a"
+              fullnameOverride: "tx-backend-postgresql-stable-a"
+              auth:
+                postgresPassword: "<path:traceability-foss/data/stable-a/database#postgresPassword>"
+                password: "<path:traceability-foss/data/stable-a/database#tracePassword>"
+                database: "trace"
+                username: "trace"
+            irs-helm:
+              enabled: true
+              bpn: BPNL00000003CML1
+              nameOverride: "tx-irs-stable-a"
+              fullnameOverride: "tx-irs-stable-a"
+              namespace: product-traceability-foss
+              springprofile: dev
+              irsUrl: "https://tx-irs-stable-a.stable.demo.catena-x.net"
+              ingress:
+                enabled: true
+                hosts:
+                  - host: "tx-irs-stable-a.stable.demo.catena-x.net"
+                    paths:
+                      - path: /
+                        pathType: ImplementationSpecific
+                tls:
+                  - hosts:
+                      - "tx-irs-stable-a.stable.demo.catena-x.net"
+                    secretName: tls-secret
+              digitalTwinRegistry:
+                type: decentral
+                descriptorEndpoint: https://trace-x-registry-stable-a.stable.demo.catena-x.net/semantics/registry/api/v3.0/shell-descriptors/{aasIdentifier}
+                shellLookupEndpoint: https://trace-x-registry-stable-a.stable.demo.catena-x.net/semantics/registry/api/v3.0/lookup/shells?assetIds={assetIds}
+                discoveryFinderUrl: https://semantics.stable.demo.catena-x.net/discoveryfinder/api/administration/connectors/discovery/search
+              semanticshub:
+                url: https://semantics.stable.demo.catena-x.net/hub/api/v1/models
+              bpdm:
+                url: https://partners-pool.stable.demo.catena-x.net
+              minioUser: '<path:traceability-foss/data/stable-a/minio#user>'
+              minioPassword: '<path:traceability-foss/data/stable-a/minio#password>'
+              minioUrl: http://tx-irs-minio-stable-a:9000
+              keycloak:
+                oauth2:
+                  clientId: '<path:traceability-foss/data/stable-a/keycloak/oauth2#clientId>'
+                  clientSecret: '<path:traceability-foss/data/stable-a/keycloak/oauth2#clientSecret>'
+                  clientTokenUri: https://centralidp.stable.demo.catena-x.net/auth/realms/CX-Central/protocol/openid-connect/token
+                  jwkSetUri: https://centralidp.stable.demo.catena-x.net/auth/realms/CX-Central/protocol/openid-connect/certs
+              edc:
+                callbackurl: http://tx-irs-stable-a:8181/internal/endpoint-data-reference
+                catalog:
+                  cache:
+                    enabled: "false"
+                controlplane:
+                  endpoint:
+                    statesuffix: /state
+                    data: https://tx-edc-consumer-stable-a-controlplane.stable.demo.catena-x.net/management
+                  apikey:
+                    secret: '<path:traceability-foss/data/stable-a/edc/controlplane#edc.api.control.auth.apikey.value>'
+              minio:
+                nameOverride: "tx-irs-minio-stable-a"
+                fullnameOverride: "tx-irs-minio-stable-a"
+                serviceAccount:
+                  create: false
+                rootUser: '<path:traceability-foss/data/stable-a/minio#user>'
+                rootPassword: '<path:traceability-foss/data/stable-a/minio#password>'
+            tractusx-connector:
+              nameOverride: "tx-edc-consumer-stable-a"
+              fullnameOverride: "tx-edc-consumer-stable-a"
+              enabled: true
+              install:
+                postgresql: false
+                vault: false
+              participant:
+                id: BPNL00000003CML1
+              controlplane:
+                ingresses:
+                  - enabled: true
+                    hostname: "tx-edc-consumer-stable-a-controlplane.stable.demo.catena-x.net"
+                    annotations:
+                      nginx.ingress.kubernetes.io/ssl-passthrough: "false"
+                      nginx.ingress.kubernetes.io/backend-protocol: "HTTP"
+                      nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
+                    endpoints:
+                      - protocol
+                      - management
+                    tls:
+                      enabled: true
+                      secretName: tls-secret
+                ssi:
+                  miw:
+                    url: '<path:traceability-foss/data/stable-a/edc/wallet#ssi.miw.url>'
+                    authorityId: '<path:traceability-foss/data/stable-a/edc/wallet#ssi.miw.authorityId>'
+                  oauth:
+                    tokenurl: '<path:traceability-foss/data/stable-a/edc/wallet#ssi.oauth.tokenurl>'
+                    client:
+                      id: '<path:traceability-foss/data/stable-a/edc/wallet#ssi.oauth.client.id>'
+                      secretAlias: edc-miw-keycloak-secret-stable-a
+                endpoints:
+                  default:
+                    port: 8080
+                    path: /api
+                  management:
+                    port: 8081
+                    path: /management
+                    authKey: '<path:traceability-foss/data/stable-a/edc/controlplane#edc.api.control.auth.apikey.value>'
+                  control:
+                    port: 8083
+                    path: /control
+                  protocol:
+                    port: 8084
+                    path: /api/v1/dsp
+                  metrics:
+                    port: 9090
+                    path: /metrics
+                  observability:
+                    port: 8085
+                    path: /observability
+                    insecure: true
+                internationalDataSpaces:
+                  id: TXDC
+                  description: Tractus-X Eclipse IDS Data Space Connector
+                  title: ""
+                  maintainer: ""
+                  curator: ""
+                  catalogId: TXDC-Catalog
+                url:
+                  ids: ""
+                resources:
+                  limits:
+                    cpu: 400m
+                    memory: 1.5Gi
+                  requests:
+                    cpu: 200m
+                    memory: 1.5Gi
+              dataplane:
+                ingresses:
+                  - enabled: true
+                    hostname: "tx-edc-consumer-stable-a-dataplane.stable.demo.catena-x.net"
+                    annotations:
+                      nginx.ingress.kubernetes.io/ssl-passthrough: "false"
+                      nginx.ingress.kubernetes.io/backend-protocol: "HTTP"
+                      nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
+                    endpoints:
+                      - public
+                    className: "nginx"
+                    tls:
+                      enabled: true
+                      secretName: tls-secret
+                endpoints:
+                  default:
+                    port: 8080
+                    path: /api
+                  public:
+                    port: 8081
+                    path: /api/public
+                  control:
+                    port: 8083
+                    path: /api/dataplane/control
+                  observability:
+                    port: 8085
+                    path: /observability
+                    insecure: true
+                  metrics:
+                    port: 9090
+                    path: /metrics
+                url:
+                  public: ""
+                resources:
+                  limits:
+                    cpu: 200m
+                    memory: 512Mi
+                  requests:
+                    cpu: 100m
+                    memory: 512Mi
+              backendService:
+                httpProxyTokenReceiverUrl: "https://traceability-stable-a.stable.demo.catena-x.net/api/callback/endpoint-data-reference"
+              securityContext:
+                readOnlyRootFilesystem: false
+              vault:
+                hashicorp:
+                  url: "https://vault.demo.catena-x.net"
+                  token: "<path:traceability-foss/data/stable-a/edc#edc.vault.hashicorp.token>"
+                  timeout: 30
+                  healthCheck:
+                    enabled: true
+                    standbyOk: true
+                  paths:
+                    secret: /v1/traceability-foss
+                    health: /v1/sys/health
+                secretNames:
+                  transferProxyTokenSignerPrivateKey: daps-cert-key-stable-a
+                  transferProxyTokenSignerPublicKey: daps-cert-stable-a
+                  transferProxyTokenEncryptionAesKey: token-signer-aes-key
+              postgresql:
+                enabled: true
+                size: 1Gi
+                auth:
+                  username: "<path:traceability-foss/data/stable-a/edc/database#user>"
+                  password: "<path:traceability-foss/data/stable-a/edc/database#password>"
+                username: "<path:traceability-foss/data/stable-a/edc/database#user>"
+                password: "<path:traceability-foss/data/stable-a/edc/database#password>"
+                jdbcUrl: "jdbc:postgresql://tx-edc-consumer-postgresql-stable-a-hl:5432/edc"
+            edc-postgresql:
+              primary:
+                resources:
+                  limits:
+                    cpu: 200m
+                    memory: 1Gi
+                  requests:
+                    cpu: 100m
+                    memory: 1Gi
+              nameOverride: "tx-edc-consumer-postgresql-stable-a"
+              fullnameOverride: "tx-edc-consumer-postgresql-stable-a"
+              enabled: true
+              auth:
+                database: edc
+                username: '<path:traceability-foss/data/stable-a/edc/database#user>'
+                postgresPassword: '<path:traceability-foss/data/stable-a/edc/database#password>'
+                password: '<path:traceability-foss/data/stable-a/edc/database#password>'

--- a/stable/3.2/tx-stable-b.yaml
+++ b/stable/3.2/tx-stable-b.yaml
@@ -1,0 +1,375 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: tx-stable-b
+  namespace: argocd
+spec:
+  project: project-traceability-foss
+  destination:
+    server: 'https://kubernetes.default.svc'
+    namespace: product-traceability-foss
+  source:
+    repoURL: 'https://eclipse-tractusx.github.io/charts/dev'
+    targetRevision: 1.3.18
+    chart: traceability-foss
+    plugin:
+      env:
+        - name: HELM_VALUES
+          value: |
+            global:
+              enablePrometheus: false
+              enableGrafana: false
+            frontend:
+              image:
+                repository: ghcr.io/catenax-ng/tx-traceability-foss
+                tag: 6.0.1-rc4
+                CATENAX_PORTAL_API_URL: '<path:traceability-foss/data/stable-b/frontend#catenax_portal_api_url>'
+                CATENAX_PORTAL_KEYCLOAK_URL: '<path:traceability-foss/data/stable-b/frontend#catenax_portal_keycloak_url>'
+                CATENAX_PORTAL_BACKEND_DOMAIN: '<path:traceability-foss/data/stable-b/frontend#catenax_portal_backend_domain>'
+                CATENAX_PORTAL_URL: '<path:traceability-foss/data/stable-b/frontend#catenax_portal_url>'
+                CATENAX_PORTAL_CLIENT_ID: '<path:traceability-foss/data/stable-b/frontend#catenax_portal_client_id>'
+              nameOverride: "tx-frontend-stable-b"
+              fullnameOverride: "tx-frontend-stable-b"
+              ingress:
+                enabled: true
+                className: "nginx"
+                annotations:
+                  cert-manager.io/cluster-issuer: letsencrypt-prod
+                hosts:
+                  - host: "traceability-portal-stable-b.stable.demo.catena-x.net"
+                    paths:
+                      - path: /
+                        pathType: ImplementationSpecific
+                tls:
+                  - hosts:
+                      - "traceability-portal-stable-b.stable.demo.catena-x.net"
+                    secretName: "traceability-portal-stable-b.stable.demo.catena-x.net-tls"
+            backend:
+              image:
+                repository: ghcr.io/catenax-ng/tx-traceability-foss
+                tag: 6.0.1-rc4
+              nameOverride: "tx-backend-stable-b"
+              fullnameOverride: "tx-backend-stable-b"
+              podSecurityContext:
+                runAsUser: 10001
+                seccompProfile:
+                  type: RuntimeDefault
+              securityContext:
+                allowPrivilegeEscalation: false
+                runAsNonRoot: true
+                runAsUser: 10001
+                runAsGroup: 3000
+                capabilities:
+                  drop:
+                    - ALL
+                readOnlyRootFilesystem: false
+              resources:
+                limits:
+                  cpu: 500m
+                  memory: 512Mi
+                requests:
+                  cpu: 100m
+                  memory: 512Mi
+              springprofile: dev
+              ingress:
+                enabled: true
+                className: "nginx"
+                annotations:
+                  nginx.ingress.kubernetes.io/backend-protocol: HTTP
+                hosts:
+                  - host: "traceability-stable-b.stable.demo.catena-x.net"
+                    paths:
+                      - path: /
+                        pathType: ImplementationSpecific
+                tls:
+                  - hosts:
+                      - "traceability-stable-b.stable.demo.catena-x.net"
+                    secretName: tls-secret
+
+              traceability:
+                bpn: "BPNL00000003CNKC"
+                url: "https://traceability-stable-b.stable.demo.catena-x.net"
+              datasource:
+                url: jdbc:postgresql://tx-backend-postgresql-stable-b:5432/trace
+                username: trace
+                password: '<path:traceability-foss/data/stable-b/database#tracePassword>'
+              oauth2:
+                clientId: '<path:traceability-foss/data/stable-b/keycloak/oauth2#clientId>'
+                clientSecret: '<path:traceability-foss/data/stable-b/keycloak/oauth2#clientSecret>'
+                clientTokenUri: "https://centralidp.stable.demo.catena-x.net/auth/realms/CX-Central/protocol/openid-connect/token"
+                jwkSetUri: "https://centralidp.stable.demo.catena-x.net/auth/realms/CX-Central/protocol/openid-connect/certs"
+                resourceClient: "app8"
+              edc:
+                apiKey: "<path:traceability-foss/data/stable-b/edc/controlplane#edc.api.control.auth.apikey.value>"
+                providerUrl: "https://tx-edc-consumer-stable-b-controlplane.stable.demo.catena-x.net"
+                callbackUrl: "http://tx-irs-stable-b:8181/internal/endpoint-data-reference"
+                callbackUrlEdcClient: "https://traceability-stable-b.stable.demo.catena-x.net/api/internal/endpoint-data-reference"
+                dataEndpointUrl: "https://tx-edc-consumer-stable-b-controlplane.stable.demo.catena-x.net/management"
+              discoveryfinder:
+                baseUrl: "https://semantics.stable.demo.catena-x.net/discoveryfinder/api/administration/connectors/discovery/search"
+              config:
+                allowedCorsOriginFirst: "http://localhost:4200/"
+                allowedCorsOriginSecond: "https://traceability-portal-stable-b.stable.demo.catena-x.net/"
+              irs:
+                baseUrl: "https://tx-irs-stable-b.stable.demo.catena-x.net"
+              registry:
+                urlWithPath: "https://trace-x-registry-stable-b.stable.demo.catena-x.net/semantics/registry/api/v3.0"
+              portal:
+                baseUrl: "https://portal-backend.stable.demo.catena-x.net/api"
+              dependencies:
+                enabled: true
+                irs: "tx-irs-stable-b"
+                edc: "tx-edc-consumer-stable-b"
+            pgadmin4:
+              nameOverride: "tx-pgadmin-stable-b"
+              fullnameOverride: "tx-pgadmin-stable-b"
+              enabled: true
+              strategy:
+                type: Recreate
+              networkPolicy:
+                enabled: false
+              ingress:
+                enabled: true
+                annotations:
+                  kubernetes.io/ingress.class: nginx
+                  nginx.ingress.kubernetes.io/backend-protocol: HTTP
+                hosts:
+                  - host: tx-pgadmin-stable-b.stable.demo.catena-x.net
+                    paths:
+                      - path: /
+                        pathType: Prefix
+                tls:
+                  - hosts:
+                      - tx-pgadmin-stable-b.stable.demo.catena-x.net
+                    secretName: tls-secret
+              env:
+                email: pgadmin4@trace.foss
+                password: "<path:traceability-foss/data/stable-b/database#pgadminPassword>"
+                variables:
+                  - name: PGADMIN_CONFIG_UPGRADE_CHECK_ENABLED
+                    value: "False"
+              resources:
+                limits:
+                  cpu: 200m
+                  memory: 512Gi
+                requests:
+                  cpu: 100m
+                  memory: 512Mi
+            postgresql:
+              enabled: true
+              nameOverride: "tx-backend-postgresql-stable-b"
+              fullnameOverride: "tx-backend-postgresql-stable-b"
+              auth:
+                postgresPassword: "<path:traceability-foss/data/stable-b/database#postgresPassword>"
+                password: "<path:traceability-foss/data/stable-b/database#tracePassword>"
+                database: "trace"
+                username: "trace"
+            irs-helm:
+              enabled: true
+              bpn: BPNL00000003CNKC
+              nameOverride: "tx-irs-stable-b"
+              fullnameOverride: "tx-irs-stable-b"
+              namespace: product-traceability-foss
+              springprofile: dev
+              irsUrl: "https://tx-irs-stable-b.stable.demo.catena-x.net"
+              ingress:
+                enabled: true
+                hosts:
+                  - host: "tx-irs-stable-b.stable.demo.catena-x.net"
+                    paths:
+                      - path: /
+                        pathType: ImplementationSpecific
+                tls:
+                  - hosts:
+                      - "tx-irs-stable-b.stable.demo.catena-x.net"
+                    secretName: tls-secret
+              digitalTwinRegistry:
+                type: decentral
+                descriptorEndpoint: https://trace-x-registry-stable-b.stable.demo.catena-x.net/semantics/registry/api/v3.0/shell-descriptors/{aasIdentifier}
+                shellLookupEndpoint: https://trace-x-registry-stable-b.stable.demo.catena-x.net/semantics/registry/api/v3.0/lookup/shells?assetIds={assetIds}
+                discoveryFinderUrl: https://semantics.stable.demo.catena-x.net/discoveryfinder/api/administration/connectors/discovery/search
+              semanticshub:
+                url: https://semantics.stable.demo.catena-x.net/hub/api/v1/models
+              bpdm:
+                url: https://partners-pool.stable.demo.catena-x.net
+              minioUser: '<path:traceability-foss/data/stable-b/minio#user>'
+              minioPassword: '<path:traceability-foss/data/stable-b/minio#password>'
+              minioUrl: http://tx-irs-minio-stable-b:9000
+              keycloak:
+                oauth2:
+                  clientId: '<path:traceability-foss/data/stable-b/keycloak/oauth2#clientId>'
+                  clientSecret: '<path:traceability-foss/data/stable-b/keycloak/oauth2#clientSecret>'
+                  clientTokenUri: https://centralidp.stable.demo.catena-x.net/auth/realms/CX-Central/protocol/openid-connect/token
+                  jwkSetUri: https://centralidp.stable.demo.catena-x.net/auth/realms/CX-Central/protocol/openid-connect/certs
+              edc:
+                callbackurl: http://tx-irs-stable-b:8181/internal/endpoint-data-reference
+                catalog:
+                  cache:
+                    enabled: "false"
+                controlplane:
+                  endpoint:
+                    statesuffix: /state
+                    data: https://tx-edc-consumer-stable-b-controlplane.stable.demo.catena-x.net/management
+                  apikey:
+                    secret: '<path:traceability-foss/data/stable-b/edc/controlplane#edc.api.control.auth.apikey.value>'
+              minio:
+                nameOverride: "tx-irs-minio-stable-b"
+                fullnameOverride: "tx-irs-minio-stable-b"
+                serviceAccount:
+                  create: false
+                rootUser: '<path:traceability-foss/data/stable-b/minio#user>'
+                rootPassword: '<path:traceability-foss/data/stable-b/minio#password>'
+            tractusx-connector:
+              nameOverride: "tx-edc-consumer-stable-b"
+              fullnameOverride: "tx-edc-consumer-stable-b"
+              enabled: true
+              install:
+                postgresql: false
+                vault: false
+              participant:
+                id: BPNL00000003CNKC
+              controlplane:
+                ingresses:
+                  - enabled: true
+                    hostname: "tx-edc-consumer-stable-b-controlplane.stable.demo.catena-x.net"
+                    annotations:
+                      nginx.ingress.kubernetes.io/ssl-passthrough: "false"
+                      nginx.ingress.kubernetes.io/backend-protocol: "HTTP"
+                      nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
+                    endpoints:
+                      - protocol
+                      - management
+                    tls:
+                      enabled: true
+                      secretName: tls-secret
+                ssi:
+                  miw:
+                    url: '<path:traceability-foss/data/stable-b/edc/wallet#ssi.miw.url>'
+                    authorityId: '<path:traceability-foss/data/stable-b/edc/wallet#ssi.miw.authorityId>'
+                  oauth:
+                    tokenurl: '<path:traceability-foss/data/stable-b/edc/wallet#ssi.oauth.tokenurl>'
+                    client:
+                      id: '<path:traceability-foss/data/stable-b/edc/wallet#ssi.oauth.client.id>'
+                      secretAlias: edc-miw-keycloak-secret-stable-b
+                endpoints:
+                  default:
+                    port: 8080
+                    path: /api
+                  management:
+                    port: 8081
+                    path: /management
+                    authKey: '<path:traceability-foss/data/stable-b/edc/controlplane#edc.api.control.auth.apikey.value>'
+                  control:
+                    port: 8083
+                    path: /control
+                  protocol:
+                    port: 8084
+                    path: /api/v1/dsp
+                  metrics:
+                    port: 9090
+                    path: /metrics
+                  observability:
+                    port: 8085
+                    path: /observability
+                    insecure: true
+                internationalDataSpaces:
+                  id: TXDC
+                  description: Tractus-X Eclipse IDS Data Space Connector
+                  title: ""
+                  maintainer: ""
+                  curator: ""
+                  catalogId: TXDC-Catalog
+                url:
+                  ids: ""
+                resources:
+                  limits:
+                    cpu: 400m
+                    memory: 1.5Gi
+                  requests:
+                    cpu: 200m
+                    memory: 1.5Gi
+              dataplane:
+                ingresses:
+                  - enabled: true
+                    hostname: "tx-edc-consumer-stable-b-dataplane.stable.demo.catena-x.net"
+                    annotations:
+                      nginx.ingress.kubernetes.io/ssl-passthrough: "false"
+                      nginx.ingress.kubernetes.io/backend-protocol: "HTTP"
+                      nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
+                    endpoints:
+                      - public
+                    className: "nginx"
+                    tls:
+                      enabled: true
+                      secretName: tls-secret
+                endpoints:
+                  default:
+                    port: 8080
+                    path: /api
+                  public:
+                    port: 8081
+                    path: /api/public
+                  control:
+                    port: 8083
+                    path: /api/dataplane/control
+                  observability:
+                    port: 8085
+                    path: /observability
+                    insecure: true
+                  metrics:
+                    port: 9090
+                    path: /metrics
+                url:
+                  public: ""
+                resources:
+                  limits:
+                    cpu: 200m
+                    memory: 512Mi
+                  requests:
+                    cpu: 100m
+                    memory: 512Mi
+              backendService:
+                httpProxyTokenReceiverUrl: "https://traceability-stable-b.stable.demo.catena-x.net/api/callback/endpoint-data-reference"
+              securityContext:
+                readOnlyRootFilesystem: false
+              vault:
+                hashicorp:
+                  url: "https://vault.demo.catena-x.net"
+                  token: "<path:traceability-foss/data/stable-b/edc#edc.vault.hashicorp.token>"
+                  timeout: 30
+                  healthCheck:
+                    enabled: true
+                    standbyOk: true
+                  paths:
+                    secret: /v1/traceability-foss
+                    health: /v1/sys/health
+                secretNames:
+                  transferProxyTokenSignerPrivateKey: daps-cert-key-stable-b
+                  transferProxyTokenSignerPublicKey: daps-cert-stable-b
+                  transferProxyTokenEncryptionAesKey: token-signer-aes-key
+              postgresql:
+                enabled: true
+                size: 1Gi
+                auth:
+                  username: "<path:traceability-foss/data/stable-b/edc/database#user>"
+                  password: "<path:traceability-foss/data/stable-b/edc/database#password>"
+                username: "<path:traceability-foss/data/stable-b/edc/database#user>"
+                password: "<path:traceability-foss/data/stable-b/edc/database#password>"
+                jdbcUrl: "jdbc:postgresql://tx-edc-consumer-postgresql-stable-b-hl:5432/edc"
+            edc-postgresql:
+              primary:
+                resources:
+                  limits:
+                    cpu: 200m
+                    memory: 1Gi
+                  requests:
+                    cpu: 100m
+                    memory: 1Gi
+              nameOverride: "tx-edc-consumer-postgresql-stable-b"
+              fullnameOverride: "tx-edc-consumer-postgresql-stable-b"
+              enabled: true
+              auth:
+                database: edc
+                username: '<path:traceability-foss/data/stable-b/edc/database#user>'
+                postgresPassword: '<path:traceability-foss/data/stable-b/edc/database#password>'
+                password: '<path:traceability-foss/data/stable-b/edc/database#password>'

--- a/stable/release-23.12-apps.yaml
+++ b/stable/release-23.12-apps.yaml
@@ -12,5 +12,3 @@ spec:
     repoURL: 'https://github.com/catenax-ng/catena-x-release-deployment'
     targetRevision: HEAD
   project: default
-  syncPolicy:
-    automated:

--- a/stable/release-23.12-apps.yaml
+++ b/stable/release-23.12-apps.yaml
@@ -1,0 +1,16 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: stable-3.2
+spec:
+  destination:
+    name: ''
+    namespace: argocd
+    server: 'https://kubernetes.default.svc'
+  source:
+    path: 'stable/23.12'
+    repoURL: 'https://github.com/catenax-ng/catena-x-release-deployment'
+    targetRevision: HEAD
+  project: default
+  syncPolicy:
+    automated:

--- a/stable/release-23.12-apps.yaml
+++ b/stable/release-23.12-apps.yaml
@@ -1,7 +1,7 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
-  name: stable-3.2
+  name: stable-23.12
 spec:
   destination:
     name: ''

--- a/stable/release-3.2-apps.yaml
+++ b/stable/release-3.2-apps.yaml
@@ -12,5 +12,3 @@ spec:
     repoURL: 'https://github.com/catenax-ng/catena-x-release-deployment'
     targetRevision: HEAD
   project: default
-  syncPolicy:
-    automated:

--- a/stable/release-3.2-apps.yaml
+++ b/stable/release-3.2-apps.yaml
@@ -1,0 +1,16 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: stable-3.2
+spec:
+  destination:
+    name: ''
+    namespace: argocd
+    server: 'https://kubernetes.default.svc'
+  source:
+    path: 'stable/3.2'
+    repoURL: 'https://github.com/catenax-ng/catena-x-release-deployment'
+    targetRevision: HEAD
+  project: default
+  syncPolicy:
+    automated:


### PR DESCRIPTION
This PR persists all the currently available Argo CD apps for STABLE.
Aditonally, the 23.12 release is already prepared. Currently same config as 3.2. Only domain names are amended and a -23.12 suffix added to the subdomains